### PR TITLE
Fix bug with binary matrices having empty derivative

### DIFF
--- a/python/bipca/bipca.py
+++ b/python/bipca/bipca.py
@@ -1138,7 +1138,9 @@ class BiPCA(BiPCAEstimator):
                                         fitdict['chat'] = chat
                                         fitdict['b'] = b
                                         fitdict['c'] = c
-                                        fitdict['coefficients'] = chebfun.coefficients()
+                                        fitdict['coefficients'] = None
+                                        if chebfun is not None:
+                                            fitdict['coefficients'] = chebfun.coefficients()
             return self.plotting_spectrum
     def _quadratic_bipca(self, X, q):
         if X.shape[1]<X.shape[0]:


### PR DESCRIPTION
Fixes #5. Note that the algorithm will work with binary matrices, but that does not mean one should use them.