### PR TITLE
Upgrade docstrings across the main bipca module

### DIFF
--- a/python/bipca/__init__.py
+++ b/python/bipca/__init__.py
@@ -1,3 +1,13 @@
+"""BiPCA: Biwhitened Principal Component Analysis.
+
+A method for denoising and dimensionality reduction of count data.
+BiPCA uses Sinkhorn bistochastic scaling to biwhiten the input matrix,
+followed by singular value decomposition and optimal singular value
+shrinkage under a Marcenko-Pastur noise model. This produces denoised
+count matrices and principal components suitable for downstream analysis
+of high-dimensional count data such as single-cell RNA sequencing.
+"""
+
 from __future__ import absolute_import
 
 from importlib.metadata import version, PackageNotFoundError

--- a/python/bipca/base.py
+++ b/python/bipca/base.py
@@ -292,12 +292,14 @@ class BiPCAEstimator(BaseEstimator):
 
     @property
     def backend(self):
-        """Summary
+        """The computational backend used for matrix operations.
+
+        Defaults to ``'scipy'`` if not explicitly set.
 
         Returns
         -------
-        TYPE
-            Description
+        str
+            The current backend identifier (e.g., ``'scipy'``, ``'torch'``).
         """
         if not attr_exists_not_none(self, '_backend'):
             self._backend = 'scipy'
@@ -305,12 +307,16 @@ class BiPCAEstimator(BaseEstimator):
 
     @backend.setter
     def backend(self, val):
-        """Summary
+        """Set the computational backend and propagate to sub-estimators.
+
+        When changed, also updates the SVD and Sinkhorn backends to match,
+        unless they were not previously set.
 
         Parameters
         ----------
-        val : TYPE
-            Description
+        val : str
+            Backend identifier. Must be one of ``'scipy'``, ``'torch'``,
+            ``'torch_cpu'``, ``'torch_gpu'``, ``'dask'``, or ``''``.
         """
         val = self.isvalid_backend(val)
         if attr_exists_not_none(self, '_backend'):
@@ -333,7 +339,10 @@ class BiPCAEstimator(BaseEstimator):
         self.reset_backend()
 
     def reset_backend(self):
-        """Summary
+        """Propagate backend settings to all child objects that have a backend attribute.
+
+        Assigns the SVD backend to SVD-related objects, the Sinkhorn backend
+        to Sinkhorn-related objects, and the global backend to all others.
         """
         # Must be called after setting backends.
         attrs = self.__dict__.keys()

--- a/python/bipca/bipca.py
+++ b/python/bipca/bipca.py
@@ -54,8 +54,11 @@ from .safe_basics import (abs,
 
 class BiPCA(BiPCAEstimator):
 
-    """Bistochastic PCA:
-    Biscale and denoise according to the paper
+    """Bistochastic PCA for denoising and dimensionality reduction of count data.
+
+    BiPCA biwhitens the input count matrix using Sinkhorn bistochastic scaling,
+    computes a singular value decomposition, and applies optimal singular value
+    shrinkage under a Marcenko-Pastur noise model to produce denoised outputs.
 
     Parameters
     ----------
@@ -63,122 +66,106 @@ class BiPCA(BiPCAEstimator):
         Center the biscaled matrix before denoising. `True` introduces a dense matrix to the problem,
         which can lead to memory problems and slow results for large problems. This option is not recommended for large problems.
         Default False.
-    variance_estimator : {'quadratic','binomial'}, default 'quadratic'
+    variance_estimator : {'quadratic', 'binomial', 'normalized'}, default 'quadratic'
         Variance estimator to use when Sinkhorn biscaling.
     q : int, default 0
         Precomputed quadratic variance for generalized Poisson sinkhorn biwhitening. Used when `qits <= 1`
-    qits : int, default 21
-        Number of variance fitting cycles to run per subsample when `variance_estimator` is `'quadratic'`.
+    qits : int, default 51
+        Number of Chebyshev nodes to use per subsample when fitting the quadratic
+        variance parameter. Higher values yield more accurate fits at increased cost.
         If `qits <= 1`, then no variance fitting is performed.
     n_subsamples : int, default 5
-        Number of subsamples to consider when `variance_estimator` is `'quadratic'`
+        Number of subsamples to consider when `variance_estimator` is `'quadratic'`.
     approximate_sigma : bool, optional
-        Estimate the noise variance for the Marcenko Pastur model using a submatrix of the original data
+        Estimate the noise variance for the Marcenko Pastur model using a submatrix of the original data.
         Default True for inputs with small axis larger than 2000.
     compute_full_approx : bool, optional
         Compute the complete singular value decomposition of subsampled matrices when `approximate_sigma=True`.
         Useful for pre-computing singular values computed by `get_plotting_spectrum()` by saving a repeated SVD.
         Default True.
-    default_shrinker : {'frobenius','fro','operator','op','nuclear','nuc','hard','hard threshold','soft','soft threshold'}, default 'frobenius'
-        shrinker to use when bipca.transform is called with no argument `shrinker`.
+    default_shrinker : {'frobenius', 'fro', 'operator', 'op', 'nuclear', 'nuc', 'hard', 'hard threshold', 'soft', 'soft threshold'}, default 'frobenius'
+        Shrinker to use when ``bipca.transform`` is called with no argument `shrinker`.
     sinkhorn_tol : float, default 1e-6
-        Sinkhorn tolerance threshold
+        Sinkhorn convergence tolerance threshold.
     n_iter : int, default 500
-        Number of sinkhorn iterations before termination.
-    n_components : None, optional
-        Number of singular vectors to compute for denoising. By default, 200 are computed.
-    pca_method : str, optional
-        Description
+        Maximum number of Sinkhorn iterations before termination.
+    n_components : int or None, optional
+        Number of singular vectors to compute for denoising. By default, 200 are computed,
+        or half the smaller matrix dimension if that is less than 200.
     exact : bool, optional
         Compute SVD using any of the full, exact decompositions from the 'torch' or backend,
-        or the partial decomposition provided by scipy.sparse.linalg.svds.
-        Default True
+        or the partial decomposition provided by ``scipy.sparse.linalg.svds``.
+        Default True.
     conserve_memory : bool, optional
         Save memory footprint by storing fewer matrices in memory, instead computing them at runtime.
         Default False.
-    logger : None, optional
-        Description
+    logger : tasklogger.TaskLogger or None, optional
+        Logger instance for progress messages. If None, a default logger is created.
     verbose : int, optional
-        Description
+        Verbosity level for logging output. Default 1.
     suppress : bool, optional
-        Description
-    subsample_size : None, optional
-        Description
+        Suppress verbose output from sub-estimators (Sinkhorn, SVD, Shrinker).
+        Default True.
+    subsample_size : int, tuple, or None, optional
+        Target size for subsampled matrices used in variance estimation.
+        If an int, the smaller dimension is limited to this value. If a tuple
+        ``(M, N)``, each dimension is limited independently. Default 5000.
     backend : {'scipy', 'torch'}, optional
-        Engine to use as the backend for sinkhorn and SVD computations. Overwritten by `sinkhorn_backend` and `svd_backend`.
-        Default 'scipy'
-    svd_backend : None, optional
-        Description
-    sinkhorn_backend : None, optional
-        Description
+        Engine to use as the backend for Sinkhorn and SVD computations.
+        Overwritten by `sinkhorn_backend` and `svd_backend`. Default 'torch'.
+    svd_backend : {'scipy', 'torch'} or None, optional
+        Backend to use specifically for SVD computations. If None, falls back
+        to `backend`.
+    sinkhorn_backend : {'scipy', 'torch'} or None, optional
+        Backend to use specifically for Sinkhorn computations. If None, falls
+        back to `backend`.
     **kwargs
-        Description
-
+        Additional keyword arguments passed to the SVD and Sinkhorn constructors.
 
     Attributes
     ----------
-    approximate_sigma : TYPE
-        Description
-    backend : TYPE
-        Description
-    default_shrinker : TYPE
-        Description
-    exact : TYPE
-        Description
-    k : TYPE
-        Description
-    keep_aspect : TYPE
-        Description
+    backend : str
+        The active computation backend ('scipy' or 'torch').
+    default_shrinker : str
+        The default singular value shrinkage method.
+    exact : bool
+        Whether a full exact SVD is computed.
+    k : int
+        Number of singular vectors computed.
+    keep_aspect : bool
+        Whether subsampled matrices preserve the aspect ratio of the input.
     kst : float
-        The ks-test score achieved by the best fitting variance estimate.
-    n_iter : TYPE
-        Description
-    pca_method : TYPE
-        Description
+        The KS-test score achieved by the best fitting variance estimate.
+    n_iter : int
+        Maximum number of Sinkhorn iterations.
     q : float
         The q-value used in the biwhitening variance estimate.
-    qits : TYPE
-        Description
-    S_X : TYPE
-        Description
-    shrinker : TYPE
-        Description
-    sinkhorn : TYPE
-        Description
-    sinkhorn_backend : TYPE
-        Description
-    sinkhorn_kwargs : TYPE
-        Description
-    sinkhorn_tol : TYPE
-        Description
-    subsample_gamma : TYPE
-        Description
-    submatrix_indices : dict
-        Description
-    subsample_M : TYPE
-        Description
-    subsample_N : TYPE
-        Description
-    subsample_sinkhorn : TYPE
-        Description
-    subsample_size : TYPE
-        Description
-    svd : TYPE
-        Description
-    svd_backend : TYPE
-        Description
-    svdkwargs : TYPE
-        Description
-    variance_estimator : TYPE
-        Description
-    X : TYPE
-        Description
-    Y : TYPE
-        Description
-    Z : TYPE
-        Description
-    S_Y : TYPE
-        Description
+    qits : int
+        Number of Chebyshev nodes per subsample for variance fitting.
+    shrinker : Shrinker
+        The singular value shrinker instance.
+    sinkhorn : Sinkhorn
+        The Sinkhorn bistochastic scaling instance.
+    sinkhorn_backend : str
+        Backend used for Sinkhorn computations.
+    sinkhorn_kwargs : dict
+        Extra keyword arguments forwarded to the Sinkhorn constructor.
+    sinkhorn_tol : float
+        Sinkhorn convergence tolerance.
+    submatrix_indices : list of dict
+        Row and column indices for each subsampled submatrix.
+    subsample_size : tuple of int
+        The resolved ``(M, N)`` subsample dimensions.
+    svd : SVD
+        The SVD instance.
+    svd_backend : str
+        Backend used for SVD computations.
+    svdkwargs : dict
+        Extra keyword arguments forwarded to the SVD constructor.
+    variance_estimator : str
+        The variance estimation method in use.
+    S_Y : ndarray
+        Singular values of the biwhitened matrix (available after fitting).
     """
 
     def __init__(
@@ -291,8 +278,7 @@ class BiPCA(BiPCAEstimator):
 
     @sinkhorn.setter
     def sinkhorn(self, val):
-        """
-        """
+        """Set the Sinkhorn instance, enforcing type Sinkhorn."""
         if isinstance(val, Sinkhorn):
             self._sinkhorn = val
         else:
@@ -318,8 +304,7 @@ class BiPCA(BiPCAEstimator):
 
     @svd.setter
     def svd(self, val):
-        """
-        """
+        """Set the SVD instance, enforcing type SVD."""
         if isinstance(val, SVD):
             self._svd = val
         else:
@@ -340,8 +325,7 @@ class BiPCA(BiPCAEstimator):
 
     @shrinker.setter
     def shrinker(self, val):
-        """
-        """
+        """Set the Shrinker instance, enforcing type Shrinker."""
         if isinstance(val, Shrinker):
             self._shrinker = val
         else:
@@ -349,8 +333,7 @@ class BiPCA(BiPCAEstimator):
 
     @property
     def svd_backend(self):
-        """
-        """
+        """str : Backend used for SVD computations, falling back to ``self.backend``."""
         if not attr_exists_not_none(self, "_svd_backend"):
             return self.backend
         else:
@@ -358,8 +341,7 @@ class BiPCA(BiPCAEstimator):
 
     @svd_backend.setter
     def svd_backend(self, val):
-        """
-        """
+        """Set the SVD backend and reset dependent state."""
         val = self.isvalid_backend(val)
         if attr_exists_not_none(self, "_svd_backend"):
             if val != self._svd_backend:
@@ -371,26 +353,14 @@ class BiPCA(BiPCAEstimator):
 
     @property
     def sinkhorn_backend(self):
-        """Summary
-
-        Returns
-        -------
-        TYPE
-            Description
-        """
+        """str : Backend used for Sinkhorn computations, falling back to ``self.backend``."""
         if not attr_exists_not_none(self, "_sinkhorn_backend"):
             return self.backend
         return self._sinkhorn_backend
 
     @sinkhorn_backend.setter
     def sinkhorn_backend(self, val):
-        """Summary
-
-        Parameters
-        ----------
-        val : TYPE
-            Description
-        """
+        """Set the Sinkhorn backend and reset dependent state."""
         val = self.isvalid_backend(val)
         if attr_exists_not_none(self, "_sinkhorn_backend"):
             if val != self._sinkhorn_backend:
@@ -403,35 +373,17 @@ class BiPCA(BiPCAEstimator):
     ###general properties###
     @fitted_property
     def mp_rank(self):
-        """Summary
-
-        Returns
-        -------
-        TYPE
-            Description
-        """
+        """int : Estimated rank from the Marcenko-Pastur fit (number of signal singular values)."""
         return self._mp_rank
 
     @property
     def n_components(self):
-        """Convenience function for :attr:`k`
-
-        Returns
-        -------
-        TYPE
-            Description
-        """
+        """int : Alias for :attr:`k`, the number of singular vectors to compute."""
         return self.k
 
     @n_components.setter
     def n_components(self, val):
-        """Summary
-
-        Parameters
-        ----------
-        val : TYPE
-            Description
-        """
+        """Set the number of singular vectors to compute."""
         self.k = val
 
     @property
@@ -448,62 +400,37 @@ class BiPCA(BiPCAEstimator):
 
     @k.setter
     def k(self, k):
-        """Summary
-
-        Parameters
-        ----------
-        k : TYPE
-            Description
-        """
+        """Set the number of singular vectors to compute."""
         self._k = k
 
     @fitted_property
     def U_Y(self):
-        """Summary
-
-        Returns
-        -------
-        TYPE
-            Description
-        """
+        """ndarray : Left singular vectors of the biwhitened matrix."""
         return self.svd.U
 
     @fitted_property
     def S_Y(self):
-        """Summary
-
-        Returns
-        -------
-        TYPE
-            Description
-        """
+        """ndarray : Singular values of the biwhitened matrix."""
         return self.svd.S
 
     @fitted_property
     def V_Y(self):
-        """Summary
-
-        Returns
-        -------
-        TYPE
-            Description
-        """
+        """ndarray : Right singular vectors of the biwhitened matrix."""
 
         return self.svd.V
 
     @property
     def Y(self):
-        """Summary
+        """ndarray : The biwhitened matrix.
 
-        Returns
-        -------
-        TYPE
-            Description
+        When ``conserve_memory`` is False and the matrix has not yet been
+        computed, it is obtained via :meth:`transform` and cached. When
+        ``conserve_memory`` is True, :meth:`transform` is called each time.
 
         Raises
         ------
         RuntimeError
-            Description
+            If ``conserve_memory`` is True and no input is available.
         """
         if not self.conserve_memory:
             Y = self._Y
@@ -515,24 +442,15 @@ class BiPCA(BiPCAEstimator):
 
     @Y.setter
     def Y(self, Y):
-        """Summary
-
-                    fill_missing)
-        ----------
-        Y : TYPE
-            Description
-        """
+        """Store the biwhitened matrix when ``conserve_memory`` is False."""
         if not self.conserve_memory:
             self._Y = Y
 
     @property
     def Y(self):
-        """Summary
+        """ndarray : The biwhitened (and optionally denoised) matrix.
 
-        Returns
-        -------
-        TYPE
-            Description
+        Computed lazily and cached when ``conserve_memory`` is False.
         """
         check_is_fitted(self)
         if not self.conserve_memory:
@@ -545,28 +463,23 @@ class BiPCA(BiPCAEstimator):
 
     @Y.setter
     def Y(self, Y):
-        """Summary
-
-        Parameters
-        ----------
-        Y : TYPE
-            Description
-        """
+        """Store the biwhitened matrix when ``conserve_memory`` is False."""
         if not self.conserve_memory:
             self._Y = Y
 
     def get_Y(self, X=None):
-        """Summary
+        """Return the biwhitened matrix, optionally transforming new data.
 
         Parameters
         ----------
-        X : None, optional
-            Description
+        X : array-like or None, optional
+            New data to biwhiten. If None, the stored biwhitened matrix is
+            returned.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            The biwhitened matrix.
         """
         check_is_fitted(self)
         if X is None:
@@ -575,101 +488,65 @@ class BiPCA(BiPCAEstimator):
             return self.sinkhorn.transform(X)
 
     def unscale(self, X):
-        """Summary
+        """Reverse the Sinkhorn biwhitening transformation.
 
         Parameters
         ----------
-        X : TYPE
-            Description
+        X : array-like
+            A matrix in the biwhitened domain to map back to the original scale.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            The unscaled matrix in the original input domain.
         """
         with self.logger.task("Transform unscaling"):
             return self.sinkhorn.unscale(X)
 
     @property
     def right_biwhite(self):
-        """Summary
-            if self.P.ismissing:
-                    X = fill_missing(X)
-                    if not self.conserve_memory:
-                        self.X = X
-                else:
-                    self.P = 1
-        Returns
-        -------
-        TYPE
-            Description
-        """
+        """ndarray : Right (column) biwhitening scaling factors from Sinkhorn."""
         return self.sinkhorn.right
 
     @property
     def left_biwhite(self):
-        """Summary
-
-        Returns
-        -------
-        TYPE
-            Description
-        """
+        """ndarray : Left (row) biwhitening scaling factors from Sinkhorn."""
 
         return self.sinkhorn.left
 
     @property
     def aspect_ratio(self):
-        """Summary
-
-        Returns
-        -------
-        TYPE
-            Description
-        """
+        """float : Ratio of the smaller to the larger dimension of the input matrix."""
         m = np.min([self.M, self.N])
         n = np.max([self.M, self.N])
         return m / n
 
     @property
     def N(self):
-        """Summary
-
-        Returns
-        -------
-        TYPE
-            Description
-        """
+        """int : Number of columns in the input matrix."""
         return self._N
 
     @property
     def M(self):
-        """Summary
-
-        Returns
-        -------
-        TYPE
-            Description
-        """
+        """int : Number of rows in the input matrix."""
         return self._M
 
     def fit(self, A):
-        """Summary
+        """Fit the BiPCA model to the input count matrix.
+
+        Performs Sinkhorn biwhitening, SVD, and Marcenko-Pastur-based singular
+        value shrinkage to identify the signal rank and denoising parameters.
 
         Parameters
         ----------
-        A : TYPE
-            Description
-
-        Deleted Parameters
-        ------------------
-        X : TYPE
-            Description
+        A : array-like or AnnData, shape (n_obs, n_vars)
+            Input count matrix. Can be a dense array, sparse matrix, or an
+            AnnData object whose ``.X`` attribute contains the counts.
 
         Returns
         -------
-        TYPE
-            Description
+        self
+            The fitted BiPCA instance.
         """
         # bug: sinkhorn needs to be reset when the model is refit.
         super().fit()
@@ -920,21 +797,24 @@ class BiPCA(BiPCAEstimator):
             return X
   
     def fit_transform(self, X=None, shrinker=None, **kwargs):
-        """Fit the estimator, then return a denoised version of the data.
+        """Fit the model and return a denoised version of the data.
+
+        If `X` is provided, :meth:`fit` is called first. If `X` is None,
+        the model must already be fitted.
 
         Parameters
         ----------
-        X : None, optional
-            Description
-        shrinker : None, optional
-            Description
+        X : array-like or AnnData or None, optional
+            Input count matrix. If None, the model must already be fitted.
+        shrinker : {'hard', 'soft', 'frobenius', 'operator', 'nuclear'} or None, optional
+            Singular value shrinkage method. Defaults to ``self.default_shrinker``.
         **kwargs
-            Description
+            Additional keyword arguments passed to :meth:`transform`.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            The denoised matrix.
         """
         if X is None:
             check_is_fitted(self)
@@ -1030,8 +910,8 @@ class BiPCA(BiPCAEstimator):
 
         Returns
         -------
-        TYPE
-            Description
+        AnnData
+            The AnnData object with BiPCA results written into it.
         """
         return write_to_adata(self, adata)
 
@@ -1131,16 +1011,21 @@ class BiPCA(BiPCAEstimator):
 
         Parameters
         ----------
-        X : None, optional
-            Description
-        n_subsamples : None, optional
-        subsample_size : None, optional
-            Description
+        reset : bool, optional
+            If True, recompute submatrix indices from scratch.
+        X : array-like or None, optional
+            The data matrix to subsample. If None, uses the stored input matrix.
+        n_subsamples : int or None, optional
+            Number of submatrices to generate. If None, uses ``self.n_subsamples``.
+        threshold : int or None, optional
+            Minimum number of nonzeros per row/column in the variance estimate.
+            If None, computed automatically from the variance structure.
 
         Returns
         -------
-        TYPE
-            Description
+        list of dict
+            Each element is a dict with keys ``'rows'`` and ``'columns'``
+            containing the index arrays for one submatrix.
         """
 
         if X is None:
@@ -1263,13 +1148,15 @@ class BiPCA(BiPCAEstimator):
         subsample : bool, optional
             Compute the covariance eigenvalues over a subset of the data
             Default False.
-        X : None, optional
-            Description
+        X : array-like or None, optional
+            The data matrix. If None, uses the stored input matrix.
 
         Returns
         -------
         dict
-            Description
+            Dictionary with keys ``'X'`` (raw spectrum, if ``get_raw=True``),
+            ``'Y'`` (biwhitened spectrum), ``'shape'``, ``'kst'``, and
+            variance parameters when applicable.
         """
         if X is None:
             X = self.X
@@ -1648,17 +1535,21 @@ class BiPCA(BiPCAEstimator):
             self.sigma = np.sqrt(chat + bhat)
 
     def fit_quadratic_variance(self, X=None):
-        """Fit the quadratic variance parameter for Poisson variance estimator
-        using a subsample of the data.
-        Returns
-        -------
-        TYPE
-            Description
+        """Fit the quadratic variance parameters via Chebyshev approximation.
+
+        Estimates ``bhat`` and ``chat`` by minimizing the KS statistic between
+        the biwhitened spectrum and a Marcenko-Pastur distribution over
+        subsampled submatrices of the data.
 
         Parameters
         ----------
-        X : None, optional
-            Description
+        X : array-like or None, optional
+            The data matrix. If None, uses the stored input matrix.
+
+        Returns
+        -------
+        tuple of float
+            ``(bhat, chat)`` -- the fitted quadratic variance parameters.
         """
         if self.bhat is not None and self.chat is not None:
             return self.bhat, self.chat

--- a/python/bipca/command_line.py
+++ b/python/bipca/command_line.py
@@ -10,6 +10,17 @@ import numpy as np
 from threadpoolctl import threadpool_limits
 import faulthandler
 def bipca_main(args = None):
+	"""Run the BiPCA pipeline from the command line.
+
+	Reads an .h5ad file, fits a BiPCA model with the specified parameters,
+	optionally computes a plotting spectrum, writes results back to the
+	AnnData object, and saves the output .h5ad file.
+
+	Parameters
+	----------
+	args : list of str or None, optional
+		Command-line arguments. If None, reads from ``sys.argv``.
+	"""
 	args = bipca_parse_args(args)
 	adata = ad.read_h5ad(args.X)
 
@@ -68,6 +79,18 @@ def bipca_main(args = None):
 	adata.write(args.Y)
 
 def bipca_parse_args(args):
+	"""Parse command-line arguments for the BiPCA CLI.
+
+	Parameters
+	----------
+	args : list of str or None
+		Command-line arguments to parse. If None, reads from ``sys.argv``.
+
+	Returns
+	-------
+	argparse.Namespace
+		Parsed arguments with backend, threading, and model parameters resolved.
+	"""
 
 	parser = argparse.ArgumentParser(prog='BiPCA', 
 		description = "Run bistochastic PCA on count data.")
@@ -169,6 +192,18 @@ def bipca_parse_args(args):
 	return args
 
 def bipca_plot_parse_args(args):
+	"""Parse command-line arguments for the BiPCA plotting CLI.
+
+	Parameters
+	----------
+	args : list of str or None
+		Command-line arguments to parse. If None, reads from ``sys.argv``.
+
+	Returns
+	-------
+	argparse.Namespace
+		Parsed arguments including input/output paths, format, and plot options.
+	"""
 	parser = argparse.ArgumentParser(prog='BiPCA_plot', description = "Plot the Marcenko-Pastur fit from a biPCA object.")
 	parser.add_argument('X', metavar='input_file',type=str, help='Path to the input .h5ad file, \n '+
 		'which has been fit previously using biPCA.')
@@ -195,6 +230,17 @@ def bipca_plot_parse_args(args):
 		raise ValueError("Input file {} does not exist.".format(args.X))
 	return args
 def bipca_plot(args = None):
+	"""Generate Marcenko-Pastur histogram, spectrum, and KS plots from a fitted BiPCA .h5ad file.
+
+	Reads a previously fitted .h5ad file and produces diagnostic plots:
+	a Marcenko-Pastur histogram, an eigenvalue spectrum bar chart, and
+	(for quadratic variance estimators) a KS statistic profile plot.
+
+	Parameters
+	----------
+	args : list of str or None, optional
+		Command-line arguments. If None, reads from ``sys.argv``.
+	"""
 	from bipca import plotting
 
 	args = bipca_plot_parse_args(args)

--- a/python/bipca/data_examples.py
+++ b/python/bipca/data_examples.py
@@ -13,22 +13,25 @@ import warnings
 
 def get_cluster_sizes(nclusters, ncells,  seed=42,**kwargs):
     """Randomly draw `nclusters` sizes that sum to `ncells`.
-    
+
+    Draws cluster sizes from a uniform multinomial distribution so that
+    each cluster has equal probability of receiving each cell.
+
     Parameters
     ----------
-    nclusters : TYPE
-        Description
-    ncells : TYPE
-        Description
-    seed : int, optional
-        Description
+    nclusters : int
+        Number of clusters to generate sizes for.
+    ncells : int
+        Total number of cells to distribute across clusters.
+    seed : int or np.random.Generator, optional
+        Random seed or an existing NumPy random Generator. Default is 42.
     **kwargs
-        Description
-    
+        Additional keyword arguments (unused, accepted for compatibility).
+
     Returns
     -------
-    TYPE
-        Description
+    cluster_sizes : ndarray of shape (nclusters,)
+        Array of cluster sizes summing to `ncells`.
     """
 
     if isinstance(seed, np.random._generator.Generator):
@@ -45,24 +48,33 @@ def get_cluster_sizes(nclusters, ncells,  seed=42,**kwargs):
 def multinomial_data(mrows=500, ncols=1000, rank=10, sample_rate=100, simple=False):
     """
     Generate multinomial distributed data of prescribed rank.
-    
+
+    Constructs a probability matrix of the given rank and samples
+    multinomial count data from it. In simple mode, columns within
+    each rank group share the same probability vector. In non-simple
+    mode, columns have random loadings over the basis.
+
     Parameters
     ----------
     mrows : int, default 500
-        Description
+        Number of rows (features) in the output matrix.
     ncols : int, default 1000
-        Description
+        Number of columns (samples) in the output matrix.
     rank : int, default 10
-        Description
+        Rank of the underlying probability matrix.
     sample_rate : int, default 100
-        Description
+        Total count parameter for each multinomial draw.
     simple : bool, optional
-        Description
-    
+        If True, columns within each rank group are identical copies
+        of a single basis vector. If False (default), columns have
+        random loadings over the basis vectors.
+
     Returns
     -------
-    TYPE
-        Description
+    X : ndarray of shape (ncols, mrows)
+        The sampled multinomial count data.
+    PX : ndarray of shape (mrows, ncols)
+        The underlying probability matrix used to generate `X`.
     """
     #the probability basis for the data
     p = np.random.multinomial(mrows,[1/mrows]*mrows,rank) / mrows
@@ -93,6 +105,37 @@ def multinomial_data(mrows=500, ncols=1000, rank=10, sample_rate=100, simple=Fal
     return X, PX
 
 def negative_binomial_data(mrows=500,ncols=1000,rank=10,b=1,c=0,sampling_SNR=1,seed=42):
+    """Generate negative binomial distributed data of prescribed rank.
+
+    Constructs a low-rank signal matrix and samples negative binomial
+    count data from it. The variance model is quadratic:
+    ``Var = b * mean + c * mean^2``.
+
+    Parameters
+    ----------
+    mrows : int, default 500
+        Number of rows (features) in the output matrix.
+    ncols : int, default 1000
+        Number of columns (samples) in the output matrix.
+    rank : int, default 10
+        Rank of the underlying signal matrix.
+    b : float, default 1
+        Linear variance coefficient.
+    c : float, default 0
+        Quadratic variance coefficient (overdispersion parameter).
+    sampling_SNR : float, default 1
+        Signal-to-noise ratio scaling applied to the signal matrix.
+    seed : int, default 42
+        Random seed for reproducibility.
+
+    Returns
+    -------
+    Y : ndarray of shape (mrows, ncols)
+        The sampled negative binomial count data.
+    X : ndarray of shape (mrows, ncols)
+        The underlying signal matrix (Poisson rate parameters before
+        negative binomial sampling).
+    """
     rng = default_rng(seed = seed)
     S = np.exp(2*rng.standard_normal(size=(mrows,rank)));
     coeff = rng.uniform(size=(rank,ncols));
@@ -125,24 +168,25 @@ def simple_poisson_data(mrows=500, ncols=1000, rank=10, sampling_SNR = 1, seed =
     Parameters
     ----------
     mrows : int, optional
-        Description
+        Number of rows (features) in the output matrix. Default is 500.
     ncols : int, optional
-        Description
+        Number of columns (samples) in the output matrix. Default is 1000.
     rank : int, optional
-        Description
-    sampling_SNR : Number, optional
-        Description
-    seed : Number, optional
-        Description
-    
+        Number of basis vectors (clusters). Default is 10.
+    sampling_SNR : float, optional
+        Signal-to-noise ratio scaling for the Poisson rate matrix.
+        Default is 1.
+    seed : int, optional
+        Random seed for reproducibility. Default is 42.
+
     Returns
     -------
-    Y : (mrows, ncols) array
-        The sampled simulation data
-    X : (mrows, ncols) array
-        The Poisson parameters used to sample Y
-    cluster_indicator : (ncols,) array
-        The indicator vector for the clusters
+    Y : ndarray of shape (mrows, ncols)
+        The sampled simulation data.
+    X : ndarray of shape (mrows, ncols)
+        The Poisson parameters used to sample Y.
+    cluster_indicator : ndarray of shape (ncols,)
+        Integer indicator vector mapping each column to its cluster.
     """
     mrows = int(mrows)
     ncols = int(ncols)
@@ -191,25 +235,31 @@ def simple_poisson_data(mrows=500, ncols=1000, rank=10, sampling_SNR = 1, seed =
     return Y, X, cluster_indicator
 
 def poisson_data(mrows=500, ncols=1000, rank=10, sampling_SNR = 1, seed = 42):
-    """Summary
-    
+    """Generate Poisson sampled data from a random low-rank signal matrix.
+
+    Constructs a rank-`rank` signal matrix from random exponential basis
+    vectors and uniform loadings, normalizes to unit mean, scales by
+    ``sampling_SNR**2``, and draws Poisson samples entry-wise.
+
     Parameters
     ----------
     mrows : int, optional
-        Description
+        Number of rows (features). Default is 500.
     ncols : int, optional
-        Description
+        Number of columns (samples). Default is 1000.
     rank : int, optional
-        Description
-    noise : int, optional
-        Description
+        Rank of the underlying signal matrix. Default is 10.
+    sampling_SNR : float, optional
+        Signal-to-noise ratio scaling. Default is 1.
     seed : int, optional
-        Description
-    
+        Random seed for reproducibility. Default is 42.
+
     Returns
     -------
-    TYPE
-        Description
+    Y : ndarray of shape (mrows, ncols)
+        The Poisson sampled count data.
+    X : ndarray of shape (mrows, ncols)
+        The underlying Poisson rate matrix.
     """
     rng = default_rng(seed = seed)
     S = np.exp(2*rng.standard_normal(size=(mrows,rank)));
@@ -463,40 +513,41 @@ def clustered_poisson(mrows=500,ncols=1000, nclusters = 5,
 class ScanpyPipeline(object):
 
     """Load an .h5ad raw dataset into ScanPy and run the standard transformations to it.
-    
+
     Attributes
     ----------
-    adata : TYPE
-        Description
-    adata_filtered : TYPE
-        Description
-    adata_raw : TYPE
-        Description
-    basename : TYPE
-        Description
-    cells_kept : TYPE
-        Description
-    fname : TYPE
-        Description
-    genes_kept : TYPE
-        Description
-    highly_variable : TYPE
-        Description
-    results_file : TYPE
-        Description
+    adata : AnnData
+        The processed AnnData object after filtering and optional normalization.
+    adata_filtered : AnnData
+        The AnnData object after cell and gene filtering but before normalization.
+    adata_raw : AnnData
+        The original unprocessed AnnData object.
+    basename : str
+        Base file path for the input dataset (as .h5ad).
+    cells_kept : ndarray of bool
+        Boolean mask indicating which cells passed filtering.
+    fname : str
+        Path to the input file.
+    genes_kept : ndarray of bool
+        Boolean mask indicating which genes passed filtering.
+    highly_variable : pandas.Series of bool
+        Boolean series indicating highly variable genes (set when ``log_normalize=True``).
+    results_file : str
+        Output file path for the processed dataset.
     """
     
     def __init__(self, fname, readfun = sc.read_h5ad, adata=None):
-        """Summary
-        
+        """Initialize the pipeline by loading or accepting an AnnData object.
+
         Parameters
         ----------
-        fname : TYPE
-            Description
-        readfun : TYPE, optional
-            Description
-        adata : None, optional
-            Description
+        fname : str
+            Path to the input data file. Used for reading and deriving output paths.
+        readfun : callable, optional
+            Function to read the data file. Default is ``scanpy.read_h5ad``.
+            If a different reader is provided, the data is converted and saved as .h5ad.
+        adata : AnnData or None, optional
+            Pre-loaded AnnData object. If provided, `readfun` is not called.
         """
         self.fname = fname
         if isinstance(adata,AnnData):
@@ -512,31 +563,37 @@ class ScanpyPipeline(object):
             self.basename = fname
 
         self.results_file = '.'.join(writename) + '_standard.h5ad'
-    def fit(self, min_genes = 100, min_cells = 100, 
-        max_n_genes_by_counts = 2500, max_n_cells_by_counts=100000, mt_pct_counts = 5, 
+    def fit(self, min_genes = 100, min_cells = 100,
+        max_n_genes_by_counts = 2500, max_n_cells_by_counts=100000, mt_pct_counts = 5,
         target_sum = 1e4,log_normalize= False, write=False,reset=False):
-        """Summary
-        
+        """Filter cells and genes, compute QC metrics, and optionally normalize.
+
+        Applies standard ScanPy quality control filtering based on minimum
+        gene/cell counts, maximum gene counts, and mitochondrial percentage.
+        Optionally performs log-normalization, highly variable gene selection,
+        regression, and scaling.
+
         Parameters
         ----------
         min_genes : int, optional
-            Description
+            Minimum number of genes expressed for a cell to pass filtering. Default is 100.
         min_cells : int, optional
-            Description
+            Minimum number of cells expressing a gene for it to pass filtering. Default is 100.
         max_n_genes_by_counts : int, optional
-            Description
+            Maximum number of genes by counts for a cell to pass filtering. Default is 2500.
         max_n_cells_by_counts : int, optional
-            Description
+            Maximum number of cells by counts for a gene to pass filtering. Default is 100000.
         mt_pct_counts : int, optional
-            Description
+            Maximum percentage of mitochondrial counts for a cell to pass filtering. Default is 5.
         target_sum : float, optional
-            Description
+            Target total count per cell for normalization. Default is 1e4.
         log_normalize : bool, optional
-            Description
+            If True, apply total-count normalization, log1p transform, highly variable
+            gene selection, regression, and scaling. Default is False.
         write : bool, optional
-            Description
+            If True, write the processed data to disk after fitting. Default is False.
         reset : bool, optional
-            Description
+            Unused parameter reserved for future use. Default is False.
         """
         adata = self.adata_raw.copy()
         ##filter cells and genes
@@ -583,14 +640,22 @@ class ScanpyPipeline(object):
         if write:
             self.write()
     def write(self, adata = None, fname = None):
-        """Summary
-        
+        """Write the processed AnnData object(s) to disk.
+
+        If no arguments are provided, writes both the raw and processed
+        datasets to their default file paths. If `adata` and `fname` are
+        provided, writes that specific AnnData to the given path.
+
         Parameters
         ----------
-        adata : None, optional
-            Description
-        fname : None, optional
-            Description
+        adata : AnnData or None, optional
+            An AnnData object to write. If None, writes the internally
+            stored raw and processed datasets.
+        fname : str or None, optional
+            Output file path. If None and `adata` is also None, uses
+            the default ``basename`` and ``results_file`` paths. If a
+            string and `adata` is None, appends 'raw' and 'standard'
+            suffixes.
         """
         if adata is None:
             if isinstance(fname, str):

--- a/python/bipca/math.py
+++ b/python/bipca/math.py
@@ -76,59 +76,54 @@ class Sinkhorn(BiPCAEstimator):
 
     Attributes
     ----------
-    backend : TYPE
-        Description
-    col_sums : TYPE
-        Description
-    column_error : TYPE
-        Description
+    backend : str
+        Computation engine used for Sinkhorn iterations.
+    col_sums : ndarray or None
+        Target column sums for biscaling.
+    column_error : float
+        Column-wise Sinkhorn convergence error after fitting.
     column_error_ : float
-        Column-wise Sinkhorn error.
+        Column-wise Sinkhorn error (stored attribute).
     converged : bool
-        Description
+        Whether the Sinkhorn iteration converged within tolerance.
     fit_ : bool
-        Description
-
-    left : TYPE
-        Description
-    left_ : array
-        Left scaling vector.
-    n_iter
-
-    poisson_kwargs : TYPE
-        Description
-    q : TYPE
-        Description
-    read_counts : TYPE
-        Description
-    right : TYPE
-        Description
-    right_ : array
-        Right scaling vector.
-    row_error : TYPE
-        Description
+        Whether the estimator has been fitted.
+    left : ndarray
+        Left (row) scaling vector. Square root of raw scalers when
+        using a variance estimator, raw scalers otherwise.
+    left_ : ndarray
+        Left scaling vector (stored attribute).
+    n_iter : int
+        Maximum number of Sinkhorn iterations.
+    q : float
+        Convex combination parameter for the quadratic variance model.
+        Set to 0 when ``variance_estimator`` is None.
+    read_counts : ndarray or int
+        Expected column sums (library sizes) used by the binomial
+        variance estimator.
+    right : ndarray
+        Right (column) scaling vector. Square root of raw scalers when
+        using a variance estimator, raw scalers otherwise.
+    right_ : ndarray
+        Right scaling vector (stored attribute).
+    row_error : float
+        Row-wise Sinkhorn convergence error after fitting.
     row_error_ : float
-        Row-wise Sinkhorn error.
-    row_sums : TYPE
-        Description
-    tol : TYPE
-        Description
-    var : TYPE
-        Description
-    variance_estimator : TYPE
-        Description
-    X : TYPE
-        Description
-    X_ : array
-        Input data.
-    Z : TYPE
-        Description
-    var
-    col_sums
-    row_sums
-    read_counts
-    tol
-    verbose
+        Row-wise Sinkhorn error (stored attribute).
+    row_sums : ndarray or None
+        Target row sums for biscaling.
+    tol : float
+        Convergence tolerance for Sinkhorn iterations.
+    var : ndarray
+        Entry-wise variance matrix estimated from the data.
+    variance_estimator : str or None
+        Name of the variance model used to estimate entry-wise variances.
+    X : ndarray or sparse matrix
+        Input data matrix stored after fitting.
+    X_ : ndarray or sparse matrix
+        Input data (stored attribute).
+    Z : ndarray or sparse matrix
+        Biscaled (transformed) data matrix.
 
     """
 
@@ -154,38 +149,43 @@ class Sinkhorn(BiPCAEstimator):
         suppress=True,
         **kwargs,
     ):
-        """Summary
+        """Initialize the Sinkhorn biscaling estimator.
 
         Parameters
         ----------
-        variance : None, optional
-            Description
-        variance_estimator : str, optional
-            Description
-        row_sums : None, optional
-            Description
-        col_sums : None, optional
-            Description
-        read_counts : None, optional
-            Description
+        variance : array-like or None, optional
+            Pre-computed entry-wise variance matrix. If None, the variance
+            is estimated from the data using ``variance_estimator``.
+        variance_estimator : str or None, optional
+            Variance model to use. One of ``'binomial'``, ``'quadratic_convex'``,
+            ``'quadratic_2param'``, ``'normalized'``, ``'empirical'``, or None
+            for vanilla biscaling without variance estimation.
+        row_sums : array-like or None, optional
+            Target row sums for biscaling. Defaults to the number of columns.
+        col_sums : array-like or None, optional
+            Target column sums for biscaling. Defaults to the number of rows.
+        read_counts : array-like or int or None, optional
+            Expected column sums (library sizes) for the binomial variance
+            estimator. Defaults to the column sums of the input data.
         tol : float, optional
-            Description
-        q : int, optional
-            Description
+            Convergence tolerance for the Sinkhorn iteration.
+        q : float, optional
+            Convex combination parameter for the quadratic variance model.
         n_iter : int, optional
-            Description
+            Maximum number of Sinkhorn iterations.
         conserve_memory : bool, optional
-            Description
+            If True, intermediate matrices are not stored after fitting.
         backend : str, optional
-            Description
-        logger : None, optional
-            Description
+            Computation engine. One of ``'scipy'``, ``'torch'``, or
+            ``'torch_gpu'``.
+        logger : tasklogger.TaskLogger or None, optional
+            Logging object. If None, a new logger is created.
         verbose : int, optional
-            Description
+            Logging verbosity level.
         suppress : bool, optional
-            Description
+            If True, suppress warnings from redundant fit calls.
         **kwargs
-            Description
+            Additional keyword arguments passed to the base estimator.
         """
         super().__init__(conserve_memory, logger, verbose, suppress, **kwargs)
 
@@ -244,17 +244,18 @@ class Sinkhorn(BiPCAEstimator):
 
     @property
     def var(self):
-        """Returns the entry-wise variance matrix estimated by estimate_variance.
+        """Return the entry-wise variance matrix estimated by estimate_variance.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray or sparse matrix
+            The estimated variance matrix with the same shape as the input data.
 
         Raises
         ------
         RuntimeError
-            Description
+            If ``conserve_memory`` is True, since the variance matrix is not
+            stored in that mode.
         """
         if not self.conserve_memory:
             return self._var
@@ -266,29 +267,32 @@ class Sinkhorn(BiPCAEstimator):
 
     @var.setter
     def var(self, var):
-        """Summary
+        """Set the variance matrix.
+
+        Only stores the value when ``conserve_memory`` is False.
 
         Parameters
         ----------
-        var : TYPE
-            Description
+        var : ndarray or sparse matrix
+            The entry-wise variance matrix to store.
         """
         if not self.conserve_memory:
             self._var = var
 
     @property
     def variance(self):
-        """Summary
+        """Alias for :attr:`var`. Return the entry-wise variance matrix.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray or sparse matrix
+            The estimated variance matrix with the same shape as the input data.
 
         Raises
         ------
         RuntimeError
-            Description
+            If ``conserve_memory`` is True, since the variance matrix is not
+            stored in that mode.
         """
         if not self.conserve_memory:
             return self._var
@@ -300,17 +304,20 @@ class Sinkhorn(BiPCAEstimator):
 
     @fitted_property
     def Z(self):
-        """Summary
+        """Return the biscaled (transformed) data matrix.
+
+        Computed lazily as ``scale(X)`` if not already cached.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray or sparse matrix
+            The biscaled data matrix, same type as the input.
 
         Raises
         ------
         RuntimeError
-            Description
+            If ``conserve_memory`` is True, since the transformed matrix is
+            not stored in that mode.
         """
         if not self.conserve_memory:
             if self._Z is None:
@@ -324,24 +331,26 @@ class Sinkhorn(BiPCAEstimator):
 
     @Z.setter
     def Z(self, Z):
-        """Summary
+        """Set the biscaled data matrix.
+
+        Only stores the value when ``conserve_memory`` is False.
 
         Parameters
         ----------
-        Z : TYPE
-            Description
+        Z : ndarray or sparse matrix
+            The biscaled data matrix to store.
         """
         if not self.conserve_memory:
             self._Z = Z
 
     @fitted_property
     def right(self):
-        """Summary
+        """Return the right (column) scaling vector.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            The right scaling vector of length N (number of columns).
         """
         if attr_exists_not_none(self, "right_"):
             return self.right_
@@ -349,23 +358,24 @@ class Sinkhorn(BiPCAEstimator):
 
     @right.setter
     def right(self, right):
-        """Summary
+        """Set the right (column) scaling vector.
 
         Parameters
         ----------
-        right : TYPE
-            Description
+        right : ndarray
+            The right scaling vector to store.
         """
         self.right_ = right
 
     @fitted_property
     def left(self):
-        """Summary
+        """Return the left (row) scaling vector.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray or None
+            The left scaling vector of length M (number of rows), or None
+            if not yet computed.
         """
         if attr_exists_not_none(self, "left_"):
             return self.left_
@@ -374,73 +384,70 @@ class Sinkhorn(BiPCAEstimator):
 
     @left.setter
     def left(self, left):
-        """Summary
+        """Set the left (row) scaling vector.
 
         Parameters
         ----------
-        left : TYPE
-            Description
+        left : ndarray
+            The left scaling vector to store.
         """
         self.left_ = left
 
     @fitted_property
     def row_error(self):
-        """Summary
+        """Return the row-wise Sinkhorn convergence error.
 
         Returns
         -------
-        TYPE
-            Description
+        float
+            Maximum absolute deviation of row sums from their targets.
         """
         return self.row_error_
 
     @row_error.setter
     def row_error(self, row_error):
-        """Summary
+        """Set the row-wise Sinkhorn convergence error.
 
         Parameters
         ----------
-        row_error : TYPE
-            Description
+        row_error : float
+            The row convergence error to store.
         """
         self.row_error_ = row_error
 
     @fitted_property
     def column_error(self):
-        """Summary
+        """Return the column-wise Sinkhorn convergence error.
 
         Returns
         -------
-        TYPE
-            Description
+        float
+            Maximum absolute deviation of column sums from their targets.
         """
         return self.row_error_
 
     @column_error.setter
     def column_error(self, column_error):
-        """Summary
+        """Set the column-wise Sinkhorn convergence error.
 
         Parameters
         ----------
-        column_error : TYPE
-            Description
+        column_error : float
+            The column convergence error to store.
         """
         self.column_error_ = column_error
 
     def __is_valid(self, X, row_sums, col_sums):
-        """Verify input data is non-negative and shapes match.
+        """Verify input data is non-negative and shapes match target sums.
 
         Parameters
         ----------
-        X : TYPE
-            Description
-        row_sums : TYPE
-            Description
-        col_sums : TYPE
-            Description
-        X : array
-        row_sums : array
-        col_sums : array
+        X : ndarray or sparse matrix
+            The input data matrix of shape ``(M, N)``.
+        row_sums : ndarray
+            Target row sums of length M.
+        col_sums : ndarray
+            Target column sums of length N.
         """
         eps = 1e-3
         assert amin(X)>=0, "Matrix is not non-negative"
@@ -453,17 +460,17 @@ class Sinkhorn(BiPCAEstimator):
         # ), "Rowsums and colsums do not add up to the same number"
 
     def __type(self, M):
-        """Typecast data matrix M based on fitted type __typef_
+        """Cast matrix to the same type as the original fitted input.
 
         Parameters
         ----------
-        M : TYPE
-            Description
+        M : ndarray or sparse matrix
+            Matrix to cast.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray or sparse matrix
+            The matrix cast to the type of the original input data.
         """
         check_is_fitted(self)
         if isinstance(M, self.__xtype):
@@ -472,17 +479,19 @@ class Sinkhorn(BiPCAEstimator):
             return self.__typef_(M)
 
     def fit_transform(self, X=None):
-        """Summary
+        """Fit the Sinkhorn estimator and return the biscaled data.
+
+        If already fitted, attempts to transform first; refits on failure.
 
         Parameters
         ----------
-        X : None, optional
-            Description
+        X : array-like or AnnData or None, optional
+            Input data matrix. If None, uses the previously fitted data.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray or sparse matrix
+            The biscaled data matrix.
         """
         if X is None:
             check_is_fitted(self)
@@ -497,18 +506,17 @@ class Sinkhorn(BiPCAEstimator):
         return self.transform(A=X)
 
     def transform(self, A=None):
-        """Scale the input by left and right Sinkhorn vectors.  Compute
+        """Scale the input by left and right Sinkhorn vectors.
 
         Parameters
         ----------
-        A : None, optional
-            Description
+        A : array-like, AnnData, or None, optional
+            Data matrix to transform. If None, uses the stored fitted data.
 
         Returns
         -------
-        type(X)
+        ndarray or sparse matrix
             Biscaled matrix of same type as input.
-
         """
         check_is_fitted(self)
 
@@ -598,22 +606,20 @@ class Sinkhorn(BiPCAEstimator):
         return len(self.right)
 
     def fit(self, A):
-        """Summary
+        """Fit the Sinkhorn biscaling estimator to the input data.
+
+        Estimates the variance matrix, computes left and right scaling
+        vectors via iterative Sinkhorn balancing, and stores the results.
 
         Parameters
         ----------
-        A : TYPE
-            Description
-
-        Deleted Parameters
-        ------------------
-        X : TYPE
-            Description
+        A : array-like or AnnData
+            Input non-negative data matrix of shape ``(M, N)``.
 
         Returns
         -------
-        TYPE
-            Description
+        Sinkhorn
+            The fitted estimator.
         """
         super().fit()
 
@@ -730,12 +736,17 @@ class Sinkhorn(BiPCAEstimator):
             self.__dimsum = lambda x, dim: x.sum(dim)
 
     def __compute_dim_sums(self):
-        """Summary
+        """Compute target row and column sums for Sinkhorn iteration.
+
+        Uses stored ``row_sums`` and ``col_sums`` if set, otherwise
+        defaults to constant vectors (N for rows, M for columns).
 
         Returns
         -------
-        TYPE
-            Description
+        row_sums : ndarray
+            Target row sums of length M.
+        col_sums : ndarray
+            Target column sums of length N.
         """
         if self.row_sums is None:
             row_sums = np.full(self._M, self._N)
@@ -750,23 +761,34 @@ class Sinkhorn(BiPCAEstimator):
     def estimate_variance(
         self, X, dist=None, q=None, bhat=None, chat=None, read_counts=None, **kwargs
     ):
-        """Estimate the element-wise variance in the matrix X
+        """Estimate the element-wise variance matrix for the input data.
+
+        Dispatches to the appropriate variance function based on the
+        selected variance estimator model.
 
         Parameters
         ----------
-        X : TYPE
-            Description
-        dist : str, optional
-            Description
-        q : int, optional
-            Description
+        X : ndarray or sparse matrix
+            Input data matrix of shape ``(M, N)``.
+        dist : str or None, optional
+            Variance model name. If None, uses ``self.variance_estimator``.
+        q : float or None, optional
+            Quadratic variance convex parameter. If None, uses ``self.q``.
+        bhat : float or None, optional
+            Quadratic 2-parameter model scale parameter.
+        chat : float or None, optional
+            Quadratic 2-parameter model curvature parameter.
+        read_counts : ndarray, int, or None, optional
+            Column-wise library sizes for the binomial model.
         **kwargs
-            Description
+            Additional keyword arguments (unused).
 
         Returns
         -------
-        TYPE
-            Description
+        var : ndarray or sparse matrix
+            Estimated entry-wise variance matrix.
+        read_counts : ndarray or int
+            The read counts used for estimation.
         """
         self.__set_operands(X)
 
@@ -804,24 +826,32 @@ class Sinkhorn(BiPCAEstimator):
         return var, read_counts
 
     def __sinkhorn(self, X, row_sums, col_sums, n_iter=None):
-        """
-        Execute Sinkhorn algorithm X mat, row_sums,col_sums for n_iter
+        """Run the Sinkhorn iteration to find left and right scaling vectors.
+
+        Iteratively computes vectors ``u`` (left) and ``v`` (right) such that
+        ``diag(u) @ X @ diag(v)`` has the prescribed row and column sums.
 
         Parameters
         ----------
-        X : TYPE
-            Description
-        row_sums : TYPE
-            Description
-        col_sums : TYPE
-            Description
-        n_iter : None, optional
-            Description
+        X : ndarray or sparse matrix
+            The matrix to biscale, typically the variance matrix.
+        row_sums : ndarray
+            Target row sums of length M.
+        col_sums : ndarray
+            Target column sums of length N.
+        n_iter : int or None, optional
+            Number of iterations. If None, uses ``self.n_iter``.
 
         Returns
         -------
-        TYPE
-            Description
+        u : ndarray
+            Left (row) scaling vector of length M.
+        v : ndarray
+            Right (column) scaling vector of length N.
+        row_error : float or None
+            Final row convergence error.
+        col_error : float or None
+            Final column convergence error.
         """
         n_row = X.shape[0]
         row_error = None
@@ -1047,43 +1077,40 @@ class SVD(BiPCAEstimator):
 
     Attributes
     ----------
-    A : TYPE
-        Description
-    backend : TYPE
-        Description
-    exact : TYPE
-        Description
-    fit_ : bool
-        Description
-    k : TYPE
-        Description
-    kwargs : TYPE
-        Description
-    S : TYPE
-        Description
-    S_ : TYPE
-        Description
-    U : TYPE
-        Description
-    U_ : TYPE
-        Description
-    V : TYPE
-        Description
-    V_ : TYPE
-        Description
-    X : TYPE
-        Description
-    U : array
-    S : array
-    V : array
-    svd : array
-    algorithm : callable
-    k : int
-    n_components : int
+    A : array-like
+        The raw input data passed to :meth:`fit`.
+    backend : {'scipy', 'torch', 'torch_gpu'}
+        The computation backend used for the SVD.
     exact : bool
+        Whether exact or approximate SVD algorithms are used.
+    fit_ : bool
+        True if the estimator has been fit.
+    k : int
+        The rank of the computed singular value decomposition.
     kwargs : dict
+        Keyword arguments passed to the underlying SVD algorithm.
+    S : numpy.ndarray
+        The singular values of the fitted matrix, sorted in descending order.
+    S_ : numpy.ndarray
+        Internal storage for singular values.
+    U : numpy.ndarray
+        The left singular vectors of the fitted matrix.
+    U_ : numpy.ndarray
+        Internal storage for left singular vectors.
+    V : numpy.ndarray
+        The right singular vectors of the fitted matrix (stored column-wise).
+    V_ : numpy.ndarray
+        Internal storage for right singular vectors.
+    X : array-like
+        The processed input matrix.
+    svd : tuple of numpy.ndarray
+        The full decomposition ``(U, S, V)``.
+    algorithm : callable
+        The SVD algorithm selected for the current data and settings.
+    n_components : int
+        Alias for :attr:`k`.
     conserve_memory : bool
-
+        If True, intermediate data matrices are removed after fitting.
 
     """
 
@@ -1139,12 +1166,12 @@ class SVD(BiPCAEstimator):
 
     @kwargs.setter
     def kwargs(self, args):
-        """Summary
+        """Set the keyword arguments for the SVD algorithm.
 
         Parameters
         ----------
-        args : TYPE
-            Description
+        args : dict
+            Dictionary of keyword arguments for the SVD algorithm.
         """
         # do some logic to check if we are truely changing the arguments.
         fit_ = hasattr(self, "U_")
@@ -1194,12 +1221,12 @@ class SVD(BiPCAEstimator):
 
     @U.setter
     def U(self, U):
-        """Summary
+        """Set the left singular vectors.
 
         Parameters
         ----------
-        U : TYPE
-            Description
+        U : numpy.ndarray
+            Left singular vectors matrix of shape ``(M, k)``.
         """
         self.U_ = U
 
@@ -1222,12 +1249,12 @@ class SVD(BiPCAEstimator):
 
     @V.setter
     def V(self, V):
-        """Summary
+        """Set the right singular vectors.
 
         Parameters
         ----------
-        V : TYPE
-            Description
+        V : numpy.ndarray
+            Right singular vectors matrix of shape ``(N, k)``.
         """
         self.V_ = V
 
@@ -1250,12 +1277,12 @@ class SVD(BiPCAEstimator):
 
     @S.setter
     def S(self, S):
-        """Summary
+        """Set the singular values.
 
         Parameters
         ----------
-        S : TYPE
-            Description
+        S : numpy.ndarray
+            Singular values array of length ``k``.
         """
         self.S_ = S
 
@@ -1276,23 +1303,23 @@ class SVD(BiPCAEstimator):
 
     @exact.setter
     def exact(self, val):
-        """Summary
+        """Set whether to use exact SVD algorithms.
 
         Parameters
         ----------
-        val : TYPE
-            Description
+        val : bool
+            If True, only exact SVD algorithms will be used.
         """
         self._exact = val
 
     @property
     def backend(self):
-        """Summary
+        """Return the computation backend for the SVD.
 
         Returns
         -------
-        TYPE
-            Description
+        str
+            One of ``'scipy'``, ``'torch'``, or ``'torch_gpu'``.
         """
         if not attr_exists_not_none(self, "_backend"):
             self._backend = "scipy"
@@ -1300,12 +1327,12 @@ class SVD(BiPCAEstimator):
 
     @backend.setter
     def backend(self, val):
-        """Summary
+        """Set the computation backend and recompute the best algorithm.
 
         Parameters
         ----------
-        val : TYPE
-            Description
+        val : str
+            One of ``'scipy'``, ``'torch'``, or ``'torch_gpu'``.
         """
         val = self.isvalid_backend(val)
         if self.backend != val:
@@ -1345,22 +1372,21 @@ class SVD(BiPCAEstimator):
         return self._algorithm
 
     def __best_algorithm(self, X=None):
-        """Summary
+        """Select the most efficient SVD algorithm for the current data and settings.
+
+        Chooses between full, partial, and randomized SVD implementations
+        based on the backend, whether exact decomposition is required, and the
+        ratio of requested rank to matrix dimensions.
 
         Parameters
         ----------
-        X : None, optional_
-            Description
+        X : array-like, optional
+            Input matrix. If None, uses the stored matrix ``self.X``.
 
         Returns
         -------
-        TYPE
-            Description
-
-        No Longer Raises
-        ----------------
-        AttributeError
-            Description
+        callable
+            The selected SVD algorithm function.
         """
         if not attr_exists_not_none(self, "_algorithm"):
             self._algorithm = None
@@ -1471,24 +1497,27 @@ class SVD(BiPCAEstimator):
         return u, s, v
 
     def __compute_partial_torch_svd(self, X, k):
-        """Summary
+        """Compute a partial (low-rank) SVD using ``torch.svd_lowrank``.
+
+        Falls back to CPU if the GPU runs out of memory.
 
         Parameters
         ----------
-        X : TYPE
-            Description
-        k : TYPE
-            Description
+        X : array-like
+            Input matrix.
+        k : int
+            Number of singular triplets to compute.
 
         Returns
         -------
-        TYPE
-            Description
+        tuple of torch.Tensor
+            ``(U, S, V)`` — left singular vectors, singular values,
+            and right singular vectors.
 
         Raises
         ------
-        e
-            Description
+        RuntimeError
+            If a CUDA error other than out-of-memory occurs.
         """
         y = make_tensor(X, keep_sparse=True)
         with torch.no_grad():
@@ -1510,24 +1539,32 @@ class SVD(BiPCAEstimator):
         return u, s, v
 
     def __compute_torch_svd(self, X, k=None):
-        """Summary
+        """Compute SVD using PyTorch, dispatching to partial or full decomposition.
+
+        Delegates to :meth:`__compute_partial_torch_svd` for sparse matrices or
+        when ``k`` is small relative to the matrix dimensions; otherwise computes
+        a full SVD (or eigendecomposition) on CPU or GPU.
 
         Parameters
         ----------
-        X : TYPE
-            Description
-        k : None, optional
-            Description
+        X : array-like or sparse matrix
+            Input data matrix.
+        k : int, optional
+            Desired rank of the decomposition.
 
         Returns
         -------
-        TYPE
-            Description
+        tuple of (Tensor or None, Tensor, Tensor or None)
+            Left singular vectors U, singular values S, and right singular
+            vectors V.  U and V are ``None`` when ``vals_only`` is True.
 
         Raises
         ------
-        e
-            Description
+        RuntimeError
+            If a CUDA out-of-memory error occurs that cannot be recovered from.
+        Exception
+            If the matrix dimensions exceed the 32-bit workspace limit and
+            ``vals_only`` is False.
         """
         y = make_tensor(X, keep_sparse=True)
         if issparse(X) or k <= np.min(X.shape) / 10:
@@ -1615,12 +1652,12 @@ class SVD(BiPCAEstimator):
 
     @n_components.setter
     def n_components(self, val):
-        """Summary
+        """Set the number of components (rank) for the decomposition.
 
         Parameters
         ----------
-        val : TYPE
-            Description
+        val : int
+            Desired number of components.
         """
         self.k = val
 
@@ -1648,12 +1685,12 @@ class SVD(BiPCAEstimator):
 
     @k.setter
     def k(self, k):
-        """Summary
+        """Set the rank of the singular value decomposition.
 
         Parameters
         ----------
-        k : TYPE
-            Description
+        k : int
+            Desired rank for the decomposition.
         """
         self.__k(k=k)
 
@@ -1664,17 +1701,17 @@ class SVD(BiPCAEstimator):
 
         Parameters
         ----------
-        k : None, optional
-            Description
-        X : None, optional
-            Description
-        suppress : None, optional
-            Description
+        k : int, optional
+            Desired rank. If None, uses the stored rank.
+        X : array-like, optional
+            Data matrix to infer rank from if ``k`` is None.
+        suppress : bool, optional
+            If True, suppress warnings about rank adjustments.
 
         Returns
         -------
-        TYPE
-            Description
+        int
+            The validated rank for the decomposition.
         """
 
         if k is None or 0:
@@ -1735,22 +1772,22 @@ class SVD(BiPCAEstimator):
         return self.__k_
 
     def __check_k_(self, k=None):
-        """Summary
+        """Validate and return the rank, falling back to the current rank.
 
         Parameters
         ----------
-        k : None, optional
-            Description
+        k : int, optional
+            Requested rank. If ``None``, defaults to ``self.k``.
 
         Returns
         -------
-        TYPE
-            Description
+        int
+            Validated rank value.
 
         Raises
         ------
         ValueError
-            Description
+            If ``k`` exceeds the fitted rank or is non-positive.
         """
         ### helper to check k and raise errors when it is bad
         if k is None or 0:
@@ -1766,32 +1803,32 @@ class SVD(BiPCAEstimator):
         return k
 
     def fit(self, A=None, k=None, exact=None):
-        """Summary
+        """Compute the singular value decomposition of the input matrix.
 
         Parameters
         ----------
-        A : None, optional
-            Description
-        k : None, optional
-            Description
-        exact : None, optional
-            Description
+        A : array-like or sparse matrix, optional
+            Input data matrix. If ``None``, uses the previously stored matrix.
+        k : int, optional
+            Desired rank of the decomposition. If ``None``, uses the current
+            value of :attr:`k`.
+        exact : bool, optional
+            If provided, overrides :attr:`exact` to force an exact or
+            approximate decomposition.
+
+        Returns
+        -------
+        self
+            The fitted SVD object.
 
         Raises
         ------
         ValueError
+            If ``k`` is invalid for the given matrix dimensions.
         NotFittedError
+            If no input data is available.
         RuntimeError
-
-        Deleted Parameters
-        ------------------
-        X : TYPE
-            Description
-
-        Returns
-        -------
-        TYPE
-            Description
+            If the backend encounters a computational error.
         """
 
         super().fit()
@@ -1903,39 +1940,43 @@ class SVD(BiPCAEstimator):
 
         Parameters
         ----------
-        X : array
-            Description
-        k : None, optional
-            Description
-        exact : None, optional
-            Description
+        X : array-like, optional
+            Data matrix to decompose. If None, uses the stored matrix.
+        k : int, optional
+            Rank of the approximation. If None, uses the stored rank.
+        exact : bool, optional
+            If True, use exact (full) SVD instead of randomized.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            The rank-``k`` approximation ``U @ diag(S) @ V^T``.
 
         Raises
         ------
         ValueError
+            If ``k`` exceeds matrix dimensions.
         NotFittedError
+            If called without data and no prior ``fit``.
         RuntimeError
+            If ``conserve_memory`` is True and no matrix is available.
 
         """
         return self.factorize(X=X, k=k, exact=exact)
 
     def PCA(self, k=None):
-        """Summary
+        """Return the rank-k principal component scores (U * S).
 
         Parameters
         ----------
-        k : None, optional
-            Description
+        k : int, optional
+            Number of components to retain. If ``None``, defaults to
+            :attr:`k`.
 
         Returns
         -------
-        TYPE
-            Description
+        numpy.ndarray
+            Principal component score matrix of shape ``(n_samples, k)``.
         """
         k = self.__check_k_(k)
         return self.U[:, :k] * self.S[:k]
@@ -2042,46 +2083,46 @@ class Shrinker(BiPCAEstimator):
     rescale_svs : bool, default True
         Rescale the shrunk singular values back to the original domain using the noise variance.
     verbose : int, optional
-        Description
+        Verbosity level.
     logger : :log:`tasklogger.TaskLogger < >`, optional
-        Description
+        Logger instance for progress tracking.
 
     Attributes
     ----------
-    A : TYPE
-        Description
-    cov_eigs_ : TYPE
-        Description
-    default_shrinker : str,optional
-        Description
-    emp_qy_ : TYPE
-        Description
-    gamma_ : TYPE
-        Description
-    M_ : TYPE
-        Description
-    MP : TYPE
-        Description
-    N_ : TYPE
-        Description
-    quantile_ : TYPE
-        Description
-    rescale_svs : TYPE
-        Description
-    scaled_cov_eigs_ : TYPE
-        Description
-    scaled_cutoff_ : TYPE
-        Description
-    scaled_mp_rank_ : TYPE
-        Description
-    sigma_ : TYPE
-        Description
-    theory_qy_ : TYPE
-        Description
-    unscaled_mp_rank_ : TYPE
-        Description
-    y_ : TYPE
-        Description
+    A : ndarray
+        The rank-``k`` approximation matrix after shrinkage.
+    cov_eigs_ : ndarray
+        Covariance eigenvalues (squared singular values divided by N).
+    default_shrinker : str
+        Default shrinkage loss function name.
+    emp_qy_ : float
+        Empirical quantile of the singular values.
+    gamma_ : float
+        Fitted aspect ratio ``M / N``.
+    M_ : int
+        Number of rows of the fitted data.
+    MP : MarcenkoPastur
+        Fitted Marcenko-Pastur distribution instance.
+    N_ : int
+        Number of columns of the fitted data.
+    quantile_ : float
+        Quantile used for noise variance estimation.
+    rescale_svs : bool
+        Whether to rescale shrunk singular values.
+    scaled_cov_eigs_ : ndarray
+        Covariance eigenvalues scaled by the noise variance.
+    scaled_cutoff_ : float
+        Scaled Marcenko-Pastur upper edge cutoff.
+    scaled_mp_rank_ : int
+        Number of singular values above the scaled MP cutoff.
+    sigma_ : float
+        Estimated noise standard deviation.
+    theory_qy_ : float
+        Theoretical quantile for the noise bulk boundary.
+    unscaled_mp_rank_ : int
+        Number of singular values above the unscaled MP cutoff.
+    y_ : ndarray
+        Fitted singular values.
     nuclear
 
     Methods
@@ -2092,8 +2133,8 @@ class Shrinker(BiPCAEstimator):
 
     Deleted Attributes
     ------------------
-    logger : TYPE
-        Description
+    logger : object
+        Previously used logger attribute (removed).
 
     """
 
@@ -2109,28 +2150,25 @@ class Shrinker(BiPCAEstimator):
         suppress=True,
         **kwargs,
     ):
-        """Summary
-
+        """Initialize the Shrinker with shrinkage and estimation options.
 
         Parameters
         ----------
         default_shrinker : str, optional
-            Description
+            Shrinkage method to use by default in ``transform``.
         rescale_svs : bool, optional
-            Description
+            If True, rescale shrunk singular values back to the original
+            domain using the estimated noise variance.
         conserve_memory : bool, optional
-            Description
-        logger : None, optional
-            Description
-
+            If True, reduce memory usage at the cost of speed.
+        logger : tasklogger.TaskLogger or None, optional
+            Logger instance for status messages.
         verbose : int, optional
-            Description
+            Verbosity level for log output.
         suppress : bool, optional
-            Description
+            If True, suppress non-critical log messages.
         **kwargs
-            Description
-
-
+            Additional keyword arguments passed to the parent estimator.
         """
         super().__init__(conserve_memory, logger, verbose, suppress, **kwargs)
         self.default_shrinker = default_shrinker
@@ -2140,310 +2178,316 @@ class Shrinker(BiPCAEstimator):
     # these are just wrappers for transform.
     @fitted_property
     def frobenius(self):
-        """Summary
+        """Shrunk singular values using the Frobenius-norm optimal shrinker.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Singular values after Frobenius-norm optimal shrinkage.
         """
         check_is_fitted(self)
         return self.transform(shrinker="fro")
 
     @fitted_property
     def operator(self):
-        """Summary
+        """Shrunk singular values using the operator-norm optimal shrinker.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Singular values after operator-norm optimal shrinkage.
         """
         check_is_fitted(self)
         return self.transform(shrinker="op")
 
     @fitted_property
     def hard(self):
-        """Summary
+        """Shrunk singular values using hard thresholding.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Singular values after hard threshold shrinkage.
         """
         check_is_fitted(self)
         return self.transform(shrinker="hard")
 
     @fitted_property
     def soft(self):
-        """Summary
+        """Shrunk singular values using soft thresholding.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Singular values after soft threshold shrinkage.
         """
         check_is_fitted(self)
         return self.transform(shrinker="soft")
 
     @fitted_property
     def nuclear(self):
-        """Summary
+        """Shrunk singular values using the nuclear-norm optimal shrinker.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Singular values after nuclear-norm optimal shrinkage.
         """
         return self.transform(shrinker="nuc")
 
     @fitted_property
     def sigma(self):
-        """Summary
+        """Estimated noise standard deviation.
 
         Returns
         -------
-        TYPE
-            Description
+        float
+            The estimated noise level from the Marcenko-Pastur fit.
         """
         return self.sigma_
 
     @sigma.setter
     def sigma(self, sigma):
-        """Summary
+        """Set the estimated noise standard deviation.
 
         Parameters
         ----------
-        sigma : TYPE
-            Description
+        sigma : float
+            Noise standard deviation value.
         """
         self.sigma_ = sigma
 
     @fitted_property
     def scaled_mp_rank(self):
-        """Summary
+        """Marcenko-Pastur rank estimated from the scaled singular values.
 
         Returns
         -------
-        TYPE
-            Description
+        int
+            Number of signal singular values above the scaled MP threshold.
         """
         return self.scaled_mp_rank_
 
     @scaled_mp_rank.setter
     def scaled_mp_rank(self, scaled_mp_rank):
-        """Summary
+        """Set the scaled Marcenko-Pastur rank.
 
         Parameters
         ----------
-        scaled_mp_rank : TYPE
-            Description
+        scaled_mp_rank : int
+            Scaled MP rank value.
         """
         self.scaled_mp_rank_ = scaled_mp_rank
 
     @fitted_property
     def scaled_cutoff(self):
-        """Summary
+        """Singular value cutoff for the scaled spectrum.
 
         Returns
         -------
-        TYPE
-            Description
+        float
+            Threshold above which singular values are considered signal.
         """
         return self.scaled_cutoff_
 
     @scaled_cutoff.setter
     def scaled_cutoff(self, scaled_cutoff):
-        """Summary
+        """Set the scaled singular value cutoff.
 
         Parameters
         ----------
-        scaled_cutoff : TYPE
-            Description
+        scaled_cutoff : float
+            Scaled cutoff value.
         """
         self.scaled_cutoff_ = scaled_cutoff
 
     @fitted_property
     def unscaled_mp_rank(self):
-        """Summary
+        """Marcenko-Pastur rank estimated from the unscaled singular values.
 
         Returns
         -------
-        TYPE
-            Description
+        int
+            Number of signal singular values above the unscaled MP threshold.
         """
         return self.unscaled_mp_rank_
 
     @unscaled_mp_rank.setter
     def unscaled_mp_rank(self, unscaled_mp_rank):
-        """Summary
+        """Set the unscaled Marcenko-Pastur rank.
 
         Parameters
         ----------
-        unscaled_mp_rank : TYPE
-            Description
+        unscaled_mp_rank : int
+            Unscaled MP rank value.
         """
         self.unscaled_mp_rank_ = unscaled_mp_rank
 
     @fitted_property
     def gamma(self):
-        """Summary
+        """Aspect ratio of the data matrix (rows / columns).
 
         Returns
         -------
-        TYPE
-            Description
+        float
+            The aspect ratio gamma = M / N used in Marcenko-Pastur fitting.
         """
         return self.gamma_
 
     @gamma.setter
     def gamma(self, gamma):
-        """Summary
+        """Set the aspect ratio.
 
         Parameters
         ----------
-        gamma : TYPE
-            Description
+        gamma : float
+            Aspect ratio value.
         """
         self.gamma_ = gamma
 
     @fitted_property
     def emp_qy(self):
-        """Summary
+        """Empirical quantile function of the singular values.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Empirical quantile values of the observed singular value distribution.
         """
         return self.emp_qy_
 
     @emp_qy.setter
     def emp_qy(self, emp_qy):
-        """Summary
+        """Set the empirical quantile function.
 
         Parameters
         ----------
-        emp_qy : TYPE
-            Description
+        emp_qy : ndarray
+            Empirical quantile values.
         """
         self.emp_qy_ = emp_qy
 
     @fitted_property
     def theory_qy(self):
-        """Summary
+        """Theoretical quantile function from the Marcenko-Pastur distribution.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Theoretical MP quantile values used to estimate noise.
         """
         return self.theory_qy_
 
     @theory_qy.setter
     def theory_qy(self, theory_qy):
-        """Summary
+        """Set the theoretical quantile function.
 
         Parameters
         ----------
-        theory_qy : TYPE
-            Description
+        theory_qy : ndarray
+            Theoretical MP quantile values.
         """
         self.theory_qy_ = theory_qy
 
     @fitted_property
     def quantile(self):
-        """Summary
+        """Quantile points used for the QQ-plot fitting.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Quantile evaluation points.
         """
         return self.quantile_
 
     @quantile.setter
     def quantile(self, quantile):
-        """Summary
+        """Set the quantile points.
 
         Parameters
         ----------
-        quantile : TYPE
-            Description
+        quantile : ndarray
+            Quantile evaluation points.
         """
         self.quantile_ = quantile
 
     @fitted_property
     def scaled_cov_eigs(self):
-        """Summary
+        """Covariance eigenvalues estimated from the scaled singular values.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Scaled covariance eigenvalues (squared singular values / N).
         """
         return self.scaled_cov_eigs_
 
     @scaled_cov_eigs.setter
     def scaled_cov_eigs(self, scaled_cov_eigs):
-        """Summary
+        """Set the scaled covariance eigenvalues.
 
         Parameters
         ----------
-        scaled_cov_eigs : TYPE
-            Description
+        scaled_cov_eigs : ndarray
+            Scaled covariance eigenvalue array.
         """
         self.scaled_cov_eigs_ = scaled_cov_eigs
 
     @fitted_property
     def cov_eigs(self):
-        """Summary
+        """Covariance eigenvalues estimated from the unscaled singular values.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Unscaled covariance eigenvalues.
         """
         return self.cov_eigs_
 
     @cov_eigs.setter
     def cov_eigs(self, cov_eigs):
-        """Summary
+        """Set the unscaled covariance eigenvalues.
 
         Parameters
         ----------
-        cov_eigs : TYPE
-            Description
+        cov_eigs : ndarray
+            Unscaled covariance eigenvalue array.
         """
         self.cov_eigs_ = cov_eigs
 
     def fit(self, y, shape=None, sigma=None, theory_qy=None, q=None, suppress=None):
-        """Summary
+        """Estimate Marcenko-Pastur parameters and prepare for shrinkage.
 
         Parameters
         ----------
-        y : TYPE
-            Description
-        shape : None, optional
-            Description
-        sigma : None, optional
-            Description
-        theory_qy : None, optional
-            Description
-        q : None, optional
-            Description
-        suppress : None, optional
-            Description
+        y : ndarray or AnnData
+            Singular values (1-D) or a data matrix. If an AnnData object,
+            singular values are read from ``uns['SVD']['S']`` or
+            ``uns['bipca']['S']``.
+        shape : tuple of int or None, optional
+            Shape ``(M, N)`` of the original data matrix. Required when
+            ``y`` is a 1-D vector of singular values.
+        sigma : float or None, optional
+            Known noise standard deviation. If None, estimated from the
+            data via QQ-plot fitting against the Marcenko-Pastur distribution.
+        theory_qy : ndarray or None, optional
+            Pre-computed theoretical quantile values for the MP distribution.
+            If None, computed internally.
+        q : ndarray or None, optional
+            Quantile evaluation points for the QQ-plot. If None, chosen
+            automatically.
+        suppress : bool or None, optional
+            Override the instance-level suppress flag for this call.
 
         Raises
         ------
         ValueError
-            Description
+            If ``y`` is a 1-D vector and ``shape`` is not provided.
 
         Returns
         -------
-        TYPE
-            Description
+        Shrinker
+            The fitted Shrinker instance (self).
         """
         super().fit()
         if suppress is None:
@@ -2590,31 +2634,33 @@ class Shrinker(BiPCAEstimator):
     def _estimate_MP_params(
         self, y=None, M=None, N=None, theory_qy=None, q=None, sigma=None
     ):
-        """Summary
+        """Estimate Marcenko-Pastur distribution parameters from singular values.
 
         Parameters
         ----------
-        y : None, optional
-            Description
-        M : None, optional
-            Description
-        N : None, optional
-            Description
-        theory_qy : None, optional
-            Description
-        q : None, optional
-            Description
-        sigma : None, optional
-            Description
+        y : array-like, optional
+            Singular values. If None, uses the fitted values.
+        M : int, optional
+            Number of rows. If None, uses the fitted value.
+        N : int, optional
+            Number of columns. If None, uses the fitted value.
+        theory_qy : float, optional
+            Theoretical quantile for the noise bulk boundary.
+        q : float, optional
+            Quantile parameter for noise variance estimation.
+        sigma : float, optional
+            Precomputed noise standard deviation.
 
         Returns
         -------
-        TYPE
-            Description
-        P *
+        tuple
+            Estimated MP parameters including sigma, gamma, cutoff, and
+            covariance eigenvalues.
+
+        Raises
         ------
         ValueError
-            Description
+            If ``theory_qy`` is specified without ``q``.
         """
         with self.logger.task("MP Parameter estimate"):
             if np.any([y, M, N] == None):
@@ -2666,23 +2712,23 @@ class Shrinker(BiPCAEstimator):
         )
 
     def fit_transform(self, y=None, shape=None, shrinker=None, rescale=None):
-        """Summary
+        """Fit the model and return optimally shrunk singular values.
 
         Parameters
         ----------
-        y : None, optional
-            Description
-        shape : None, optional
-            Description
-        shrinker : None, optional
-            Description
-        rescale : None, optional,q
-            Description
+        y : array-like, optional
+            Singular values. If None, uses the fitted values.
+        shape : tuple, optional
+            Shape ``(M, N)`` of the original data matrix.
+        shrinker : str, optional
+            Shrinkage loss function to apply. If None, uses the default.
+        rescale : bool, optional
+            Whether to rescale shrunk values back to the original scale.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Optimally shrunk singular values.
         """
         self.fit(y, shape)
         if shrinker is None:
@@ -2690,21 +2736,21 @@ class Shrinker(BiPCAEstimator):
         return self.transform(y=y, shrinker=shrinker)
 
     def transform(self, y=None, shrinker=None, rescale=None):
-        """Summary
+        """Apply optimal shrinkage to singular values.
 
         Parameters
         ----------
-        y : None, optional
-            Description
-        shrinker : None, optional
-            Description
-        rescale : None, optional
-            Description
+        y : array-like, optional
+            Singular values to shrink. If None, uses the fitted values.
+        shrinker : str, optional
+            Shrinkage loss function. If None, uses the default.
+        rescale : bool, optional
+            Whether to rescale shrunk values back to the original scale.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Optimally shrunk singular values.
         """
         check_is_fitted(self)
         if y is None:
@@ -2731,18 +2777,20 @@ class Shrinker(BiPCAEstimator):
 
 def general_variance(X):
     """
-    Estimated variance under a general model.
+    Estimate entry-wise variance under a general (empirical) model.
+
+    Computes the squared absolute values of the mean-centered data as
+    a plug-in variance estimate.
 
     Parameters
     ----------
-    X : array-like
-        Description
+    X : ndarray or sparse matrix
+        Input non-negative data matrix of shape ``(M, N)``.
 
     Returns
     -------
-    np.array
-        Description
-
+    ndarray
+        Entry-wise variance estimates of the same shape as ``X``.
     """
     Y = MeanCenteredMatrix().fit_transform(X)
     if issparse(X, check_torch=False):
@@ -2753,19 +2801,23 @@ def general_variance(X):
 
 def quadratic_variance_convex(X, q=0):
     """
-    Estimated variance under the quadratic variance count model with convex `q` parameter.
+    Estimate entry-wise variance under the quadratic variance model.
+
+    Computes ``(1 - q) * X + q * X**2``, a convex combination of Poisson-like
+    (linear) and overdispersed (quadratic) variance terms.
 
     Parameters
     ----------
-    X : TYPE
-        Description
-    q : int, optional
-        Description
+    X : ndarray or sparse matrix
+        Input non-negative data matrix of shape ``(M, N)``.
+    q : float, optional
+        Convex combination parameter in ``[0, 1]``. When ``q=0``, the
+        variance equals ``X`` (Poisson); when ``q=1``, it equals ``X**2``.
 
     Returns
     -------
-    TYPE
-        Description
+    ndarray or sparse matrix
+        Entry-wise variance estimates of the same shape as ``X``.
     """
     if issparse(X, check_torch=False):
         Y = X.copy()
@@ -2776,20 +2828,24 @@ def quadratic_variance_convex(X, q=0):
 
 def quadratic_variance_2param(X, bhat=1.0, chat=0):
     """
-    Estimated variance under the quadratic variance count model with 2 parameters.
+    Estimate entry-wise variance under the two-parameter quadratic model.
+
+    Computes ``bhat * X + chat * X**2``, allowing independent control of the
+    linear and quadratic variance terms.
 
     Parameters
     ----------
-    X : TYPE
-        Description
-    q : int, optional
-        Description
+    X : ndarray or sparse matrix
+        Input non-negative data matrix of shape ``(M, N)``.
+    bhat : float, optional
+        Coefficient of the linear (Poisson-like) variance term.
+    chat : float, optional
+        Coefficient of the quadratic (overdispersion) variance term.
 
     Returns
     -------
-    TYPE
-        Description
-
+    ndarray or sparse matrix
+        Entry-wise variance estimates of the same shape as ``X``.
     """
     if issparse(X, check_torch=False):
         Y = X.copy()
@@ -2800,23 +2856,22 @@ def quadratic_variance_2param(X, bhat=1.0, chat=0):
 
 def binomial_variance(X, counts):
     """
-    Estimated variance under the binomial count model.
+    Estimate entry-wise variance under the binomial count model.
+
+    Computes ``X * counts / (counts - 1) - X**2 / (counts - 1)`` and takes
+    the absolute value to ensure non-negativity.
 
     Parameters
     ----------
-    X : TYPE
-        Description
-    counts : TYPE
-        Description
-    mult : TYPE, optional
-        Description
-    square : TYPE, optional
-        Description
+    X : ndarray or sparse matrix
+        Input non-negative data matrix of shape ``(M, N)``.
+    counts : ndarray or int
+        Column-wise library sizes (read counts). Must be greater than 1.
 
     Returns
     -------
-    TYPE
-        Description
+    ndarray or sparse matrix
+        Entry-wise variance estimates of the same shape as ``X``.
     """
     if np.any(counts <= 1):
         raise ValueError("Counts must be greater than 1.")
@@ -2852,21 +2907,21 @@ from scipy.stats import rv_continuous
 
 
 class MarcenkoPastur(rv_continuous):
-    """ "marcenko-pastur
+    """Marcenko-Pastur distribution for random matrix theory.
 
     Attributes
     ----------
-    gamma : TYPE
-        Description
+    gamma : float
+        Aspect ratio of the data matrix (values > 1 are inverted).
     """
 
     def __init__(self, gamma):
-        """Summary
+        """Initialize the Marcenko-Pastur distribution.
 
         Parameters
         ----------
-        gamma : TYPE
-            Description
+        gamma : float
+            Aspect ratio ``M / N`` (values > 1 are automatically inverted).
         """
         if gamma > 1:
             gamma = 1 / gamma
@@ -2877,17 +2932,17 @@ class MarcenkoPastur(rv_continuous):
         self.gamma = gamma
 
     def _pdf(self, x):
-        """Summary
+        """Evaluate the Marcenko-Pastur probability density function.
 
         Parameters
         ----------
-        x : TYPE
-            Description
+        x : array-like
+            Points at which to evaluate the PDF.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Density values at ``x``.
         """
         m0 = lambda a: np.clip(a, 0, None)
         m0b = self.b - x
@@ -3046,21 +3101,21 @@ class SamplingMatrix(object):
 
 
 def L2(x, func1, func2):
-    """Summary
+    """Compute the squared difference (L2 loss) between two functions at ``x``.
 
     Parameters
     ----------
-    x : TYPE
-        Description
-    func1 : TYPE
-        Description
-    func2 : TYPE
-        Description
+    x : array-like
+        Points at which to evaluate the functions.
+    func1 : callable
+        First function.
+    func2 : callable
+        Second function.
 
     Returns
     -------
-    TYPE
-        Description
+    ndarray
+        Element-wise squared difference ``(func1(x) - func2(x))^2``.
     """
     return np.square(func1(x) - func2(x))
 
@@ -3075,21 +3130,19 @@ def normalized_KS(y, mp, m, r):
 
 
 def KS(y, mp):
-    """Summary
+    """Compute the Kolmogorov-Smirnov statistic against an MP distribution.
 
     Parameters
     ----------
-    y : TYPE
-        Description
-    mp : TYPE
-        Description
-    num : int, optional
-        Description
+    y : array-like
+        Observed eigenvalues or singular values.
+    mp : rv_continuous
+        Marcenko-Pastur distribution instance with a ``cdf`` method.
 
     Returns
     -------
-    TYPE
-        Description
+    float
+        The KS test statistic.
     """
     # x = np.linspace(mp.a*0.8, mp.b*1.2, num = num)
     # yesd = np.interp(x, np.flip(y), np.linspace(0,1,num=len(y),endpoint=False))
@@ -3099,44 +3152,44 @@ def KS(y, mp):
 
 
 def L1(x, func1, func2):
-    """Summary
+    """Compute the absolute difference (L1 loss) between two functions at ``x``.
 
     Parameters
     ----------
-    x : TYPE
-        Description
-    func1 : TYPE
-        Description
-    func2 : TYPE
-        Description
+    x : array-like
+        Points at which to evaluate the functions.
+    func1 : callable
+        First function.
+    func2 : callable
+        Second function.
 
     Returns
     -------
-    TYPE
-        Description
+    ndarray
+        Element-wise absolute difference ``|func1(x) - func2(x)|``.
     """
     return np.absolute(func1(x) - func2(x))
 
 
 # evaluate given loss function on a pdf and an empirical pdf (histogram data)
 def emp_pdf_loss(pdf, epdf, loss=L2, start=0):
-    """Summary
+    """Evaluate a loss between a theoretical and empirical PDF by integration.
 
     Parameters
     ----------
-    pdf : TYPE
-        Description
-    epdf : TYPE
-        Description
-    loss : TYPE, optional
-        Description
-    start : int, optional
-        Description
+    pdf : callable
+        Theoretical probability density function.
+    epdf : callable
+        Empirical probability density function.
+    loss : callable, optional
+        Loss function ``loss(x, func1, func2)``. Defaults to ``L2``.
+    start : float, optional
+        Lower integration bound. Defaults to 0.
 
     Returns
     -------
-    TYPE
-        Description
+    float
+        Integrated loss value.
     """
     # loss() should have three arguments: x, func1, func2
     # note 0 is the left limit because our pdfs are strictly supported on the non-negative reals, due to the nature of sv's
@@ -3147,32 +3200,32 @@ def emp_pdf_loss(pdf, epdf, loss=L2, start=0):
 
 
 def emp_mp_loss(mat, gamma=0, loss=L2, precomputed=True, M=None, N=None):
-    """Summary
+    """Compute the loss between empirical spectral distribution and MP law.
 
     Parameters
     ----------
-    mat : TYPE
-        Description
-    gamma : int, optional
-        Description
-    loss : TYPE, optional
-        Description
+    mat : ndarray
+        Data matrix or precomputed covariance eigenvalues.
+    gamma : float, optional
+        Aspect ratio ``M / N``. If 0, computed from ``M`` and ``N``.
+    loss : callable, optional
+        Loss function ``loss(x, func1, func2)``. Defaults to ``L2``.
     precomputed : bool, optional
-        Description
-    M : None, optional
-        Description
-    N : None, optional
-        Description
+        If True, ``mat`` contains precomputed eigenvalues.
+    M : int, optional
+        Number of rows. Required when ``precomputed`` is True.
+    N : int, optional
+        Number of columns. Required when ``precomputed`` is True.
 
     Returns
     -------
-    TYPE
-        Description
+    float
+        Integrated loss between the empirical and MP distributions.
 
     Raises
     ------
     RuntimeError
-        Description
+        If ``precomputed`` is True and ``M`` or ``N`` is None.
     """
     if precomputed:
         if M is None or N is None:
@@ -3233,25 +3286,27 @@ def emp_mp_loss(mat, gamma=0, loss=L2, precomputed=True, M=None, N=None):
 
 
 def debias_singular_values(y, m, n, gamma=None, sigma=1):
-    """Summary
+    """Remove noise bias from singular values using an optimal shrinker.
+
+    Values below ``sigma * (sqrt(n) + sqrt(m))`` are set to zero.
 
     Parameters
     ----------
-    y : TYPE
-        Description
-    m : TYPE
-        Description
-    n : TYPE
-        Description
-    gamma : None, optional
-        Description
-    sigma : int, optional
-        Description
+    y : array-like
+        Observed singular values.
+    m : int
+        Number of rows.
+    n : int
+        Number of columns.
+    gamma : float, optional
+        Aspect ratio ``m / n``. If None, computed from ``m`` and ``n``.
+    sigma : float, optional
+        Noise standard deviation. Defaults to 1.
 
     Returns
     -------
-    TYPE
-        Description
+    ndarray
+        Debiased singular values.
     """
     # optimal shrinker derived by boris for inverting singular values to remove noise
     # if sigma is 1, then y may be normalized
@@ -3279,38 +3334,39 @@ def _optimal_shrinkage(
     rescale=True,
     logger=None,
 ):
-    """Summary
+    """Apply optimal singular value shrinkage for a given loss function.
 
     Parameters
     ----------
-    unscaled_y : TYPE
-        Description
-    sigma : TYPE
-        Description
-    M : TYPE
-        Description
-    N : TYPE
-        Description
-    gamma : TYPE
-        Description
-    scaled_cutoff : None, optional
-        Description
+    unscaled_y : array-like
+        Singular values on the original (unscaled) scale.
+    sigma : float
+        Estimated noise standard deviation.
+    M : int
+        Number of rows of the data matrix.
+    N : int
+        Number of columns of the data matrix.
+    gamma : float
+        Aspect ratio ``M / N``.
+    scaled_cutoff : float, optional
+        Scaled MP upper bound. If None, computed from ``gamma``.
     shrinker : str, optional
-        Description
+        Shrinkage type: ``'frobenius'``, ``'operator'``, ``'soft'``,
+        ``'hard'``, or ``'nuclear'``. Defaults to ``'frobenius'``.
     rescale : bool, optional
-        Description
-    logger : None, optional
-        Description
+        If True, rescale shrunk values back to the original scale.
+    logger : object, optional
+        Logger instance.
 
     Returns
     -------
-    TYPE
-        Description
+    ndarray
+        Shrunk singular values.
 
     Raises
     ------
     ValueError
-        Description
+        If ``shrinker`` is not a recognized shrinkage type.
     """
     if scaled_cutoff is None:
         scaled_cutoff = scaled_mp_bound(gamma)
@@ -3365,17 +3421,17 @@ def _optimal_shrinkage(
 
 
 def scaled_mp_bound(gamma):
-    """Summary
+    """Compute the upper edge of the scaled Marcenko-Pastur distribution.
 
     Parameters
     ----------
-    gamma : TYPE
-        Description
+    gamma : float
+        Aspect ratio ``M / N``.
 
     Returns
     -------
-    TYPE
-        Description
+    float
+        Upper bound ``(1 + sqrt(gamma))^2``.
     """
     scaled_bound = (1 + np.sqrt(gamma)) ** 2
     return scaled_bound
@@ -3421,34 +3477,24 @@ class MeanCenteredMatrix(BiPCAEstimator):
     
     Attributes
     ----------
-    consider_zeros : TYPE
-        Description
+    consider_zeros : bool
+        Whether to include zeros when computing means.
     fit_ : bool
-        Description
-    M : TYPE
-        Description
-    maintain_sparsity : TYPE
-        Description
-    N : TYPE
-        Description
-    X_centered : TYPE
-        Description
-    row_means
-    column_means
-    grand_mean
-    X_centered
-    maintain_sparsity
-    consider_zeros
-    force_type
-    conserve_memory
-    verbose
-    logger
-    suppress
-    
-    Deleted Attributes
-    ------------------
-    X__centered : TYPE
-        Description
+        Whether the instance has been fitted.
+    M : int
+        Number of columns of the fitted data.
+    maintain_sparsity : bool
+        Whether to preserve sparsity during centering.
+    N : int
+        Number of rows of the fitted data.
+    X_centered : array-like
+        The mean-centered data matrix (stored if ``conserve_memory`` is False).
+    row_means : ndarray
+        Mean of each row.
+    column_means : ndarray
+        Mean of each column.
+    grand_mean : float
+        Grand mean of the matrix.
     """
 
     def __init__(
@@ -3461,24 +3507,24 @@ class MeanCenteredMatrix(BiPCAEstimator):
         suppress=True,
         **kwargs,
     ):
-        """Summary
+        """Initialize the mean centering transformer.
 
         Parameters
         ----------
         maintain_sparsity : bool, optional
-            Description
+            If True, only center nonzero elements to preserve sparsity.
         consider_zeros : bool, optional
-            Description
+            If True, include zeros when computing means.
         conserve_memory : bool, optional
-            Description
-        logger : None, optional
-            Description
+            If True, only store centering factors, not the centered matrix.
+        logger : tasklogger.TaskLogger, optional
+            Logger instance for status messages.
         verbose : int, optional
-            Description
+            Verbosity level (0, 1, or 2).
         suppress : bool, optional
-            Description
+            If True, suppress extra warnings beyond the logging level.
         **kwargs
-            Description
+            Additional keyword arguments passed to the parent estimator.
         """
         super().__init__(conserve_memory, logger, verbose, suppress, **kwargs)
         self.maintain_sparsity = maintain_sparsity
@@ -3487,68 +3533,69 @@ class MeanCenteredMatrix(BiPCAEstimator):
     @memory_conserved_property
     @fitted
     def X_centered(self):
-        """Summary
+        """The mean-centered data matrix from the last call to ``transform``.
 
         Returns
         -------
-        TYPE
-            Description
+        array-like
+            The centered data matrix.
         """
         return self._X_centered
 
     @X_centered.setter
     def X_centered(self, Mc):
-        """Summary
+        """Set the centered data matrix, stored only when memory is not conserved.
 
         Parameters
         ----------
-        Mc : TYPE
-            Description
+        Mc : array-like
+            The centered data matrix to store.
         """
         if not self.conserve_memory:
             self._X_centered = Mc
 
     @fitted_property
     def row_means(self):
-        """Summary
+        """Mean of each row computed during ``fit``.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Array of row means.
         """
         return self._row_means
 
     @fitted_property
     def column_means(self):
-        """Summary
+        """Mean of each column computed during ``fit``.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Array of column means.
         """
         return self._column_means
 
     @fitted_property
     def grand_mean(self):
-        """Summary
+        """Grand mean of the matrix computed during ``fit``.
 
         Returns
         -------
-        TYPE
-            Description
+        float
+            The scalar grand mean.
         """
         return self._grand_mean
 
     @fitted_property
     def rescaling_matrix(self):
-        """Summary
+        """Dense matrix of row, column, and grand mean corrections.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            An ``(N, M)`` array where each entry is
+            ``row_mean + column_mean - grand_mean``.
         """
         # Computes and returns the dense rescaling matrix
         mat = -1 * self._grand_mean * np.ones((self.N, self.M))
@@ -3557,19 +3604,19 @@ class MeanCenteredMatrix(BiPCAEstimator):
         return mat
 
     def __compute_grand_mean(self, X, consider_zeros=True):
-        """Summary
+        """Compute the grand mean of a matrix.
 
         Parameters
         ----------
-        X : TYPE
-            Description
+        X : array-like or sparse matrix
+            Input data matrix.
         consider_zeros : bool, optional
-            Description
+            If True, divide by total element count; otherwise by nonzero count.
 
         Returns
         -------
-        TYPE
-            Description
+        float
+            The grand mean.
         """
         if issparse(X, check_torch=False):
             nz = lambda x: x.nnz
@@ -3583,21 +3630,21 @@ class MeanCenteredMatrix(BiPCAEstimator):
         return np.sum(D) / nz(X)
 
     def __compute_dim_means(self, X, axis=0, consider_zeros=True):
-        """Summary
+        """Compute means along a given axis.
 
         Parameters
         ----------
-        X : TYPE
-            Description
+        X : array-like or sparse matrix
+            Input data matrix.
         axis : int, optional
-            Description
+            0 for column means, 1 for row means.
         consider_zeros : bool, optional
-            Description
+            If True, divide by the full dimension; otherwise by nonzero count.
 
         Returns
         -------
-        TYPE
-            Description
+        ndarray
+            Array of means along the specified axis.
         """
         # axis = 0 gives you the column means
         # axis = 1 gives row means
@@ -3612,33 +3659,33 @@ class MeanCenteredMatrix(BiPCAEstimator):
         return means
 
     def fit_transform(self, X):
-        """Summary
+        """Fit centering parameters and return the centered matrix.
 
         Parameters
         ----------
-        X : TYPE
-            Description
+        X : array-like or sparse matrix
+            Input data matrix of shape ``(N, M)``.
 
         Returns
         -------
-        TYPE
-            Description
+        array-like
+            The mean-centered data matrix.
         """
         self.fit(X)
         return self.transform(X)
 
     def fit(self, X):
-        """Summary
+        """Compute row means, column means, and grand mean from the data.
 
         Parameters
         ----------
-        X : TYPE
-            Description
+        X : array-like or sparse matrix
+            Input data matrix of shape ``(N, M)``.
 
         Returns
         -------
-        TYPE
-            Description
+        MeanCenteredMatrix
+            The fitted instance.
         """
         # let's compute the grand mean first.
         self._grand_mean = self.__compute_grand_mean(X, self.consider_zeros)
@@ -3655,17 +3702,17 @@ class MeanCenteredMatrix(BiPCAEstimator):
 
     @fitted
     def transform(self, X):
-        """Summary
+        """Subtract the fitted means from the input matrix.
 
         Parameters
         ----------
-        X : TYPE
-            Description
+        X : array-like or sparse matrix
+            Data matrix of shape ``(N, M)`` to center.
 
         Returns
         -------
-        TYPE
-            Description
+        array-like
+            The mean-centered data matrix.
         """
         # remove the means learned from .fit() from the input X.
         if self.maintain_sparsity:
@@ -3689,50 +3736,50 @@ class MeanCenteredMatrix(BiPCAEstimator):
         return X_c
 
     def scale(self, X):
-        """Summary
+        """Alias for ``transform``. Center the input matrix.
 
         Parameters
         ----------
-        X : TYPE
-            Description
+        X : array-like or sparse matrix
+            Data matrix of shape ``(N, M)`` to center.
 
         Returns
         -------
-        TYPE
-            Description
+        array-like
+            The mean-centered data matrix.
         """
         # Convenience synonym for transform
         return self.transform(X)
 
     def center(self, X):
-        """Summary
+        """Alias for ``transform``. Center the input matrix.
 
         Parameters
         ----------
-        X : TYPE
-            Description
+        X : array-like or sparse matrix
+            Data matrix of shape ``(N, M)`` to center.
 
         Returns
         -------
-        TYPE
-            Description
+        array-like
+            The mean-centered data matrix.
         """
         # Convenience synonym for transform
         return self.transform(X)
 
     @fitted
     def invert(self, X):
-        """Summary
+        """Add back the fitted means to reverse centering.
 
         Parameters
         ----------
-        X : TYPE
-            Description
+        X : array-like or sparse matrix
+            A previously centered data matrix of shape ``(N, M)``.
 
         Returns
         -------
-        TYPE
-            Description
+        array-like
+            The uncentered data matrix.
         """
         # Subtract means from the data
         if self.maintain_sparsity:
@@ -3755,33 +3802,33 @@ class MeanCenteredMatrix(BiPCAEstimator):
         return X_c
 
     def uncenter(self, X):
-        """Summary
+        """Alias for ``invert``. Reverse the centering transformation.
 
         Parameters
         ----------
-        X : TYPE
-            Description
+        X : array-like or sparse matrix
+            A previously centered data matrix of shape ``(N, M)``.
 
         Returns
         -------
-        TYPE
-            Description
+        array-like
+            The uncentered data matrix.
         """
         # Convenience synonym for invert
         return self.invert(X)
 
     def unscale(self, X):
-        """Summary
+        """Alias for ``invert``. Reverse the centering transformation.
 
         Parameters
         ----------
-        X : TYPE
-            Description
+        X : array-like or sparse matrix
+            A previously centered data matrix of shape ``(N, M)``.
 
         Returns
         -------
-        TYPE
-            Description
+        array-like
+            The uncentered data matrix.
         """
         # Convenience synonym for invert
         return self.invert(X)

--- a/python/bipca/plotting.py
+++ b/python/bipca/plotting.py
@@ -28,6 +28,15 @@ mpl.set_loglevel("NOTSET")
 
 
 def set_latex(latex=None):
+    """Toggle or set LaTeX rendering for matplotlib text.
+
+    Parameters
+    ----------
+    latex : bool or None, optional
+        If True, enable LaTeX rendering (if a TeX installation is found).
+        If False, disable LaTeX rendering. If None (default), toggle the
+        current state.
+    """
     global usetex
     if latex is None:
         latex = not usetex
@@ -345,6 +354,49 @@ def spectra_from_bipca(
     output="",
     figkwargs={},
 ):
+    """Plot eigenvalue bar charts before and after BiPCA biscaling.
+
+    Displays two bar charts of covariance eigenvalues around the estimated
+    rank: one for the unscaled covariance and one for the biscaled covariance.
+    The Marcenko-Pastur threshold and selected rank are shown as reference lines.
+
+    Parameters
+    ----------
+    bipcaobj : bipca.bipca.BiPCA or AnnData
+        A fit BiPCA estimator or an AnnData object containing BiPCA results
+        in ``uns['bipca']``.
+    scale : {'linear', 'log', 'symlog'}, optional
+        Y-axis scale for the bar charts. Default is 'linear'.
+    fig : matplotlib.figure.Figure or None, optional
+        Existing figure to plot into. If None, a new figure is created.
+    minus : list of int, optional
+        Number of eigenvalues to show below the rank for [pre, post] plots.
+        Default is [10, 10].
+    plus : list of int, optional
+        Number of eigenvalues to show above the rank for [pre, post] plots.
+        Default is [10, 10].
+    axes : list of matplotlib.axes.Axes or None, optional
+        Existing axes to plot into. If None, new axes are created.
+    dpi : int, optional
+        Figure resolution in dots per inch. Default is 300.
+    figsize : tuple of float, optional
+        Figure size in inches as (width, height). Default is (10, 5).
+    title : str, optional
+        Figure title. Default is ''.
+    output : str, optional
+        File path to save the figure. If empty string, figure is not saved.
+    figkwargs : dict, optional
+        Additional keyword arguments passed to ``get_figure``.
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+        The figure containing the plots.
+    ax1 : matplotlib.axes.Axes
+        Axes for the unscaled covariance eigenvalues.
+    ax2 : matplotlib.axes.Axes
+        Axes for the biscaled covariance eigenvalues.
+    """
     fig, axes = get_figure(fig=fig, axes=axes, dpi=dpi, figsize=figsize, **figkwargs)
     if axes is None:
         naxes = 2
@@ -455,6 +507,41 @@ def KS_from_bipca(
     labelfontsize=16,
     figkwargs={},
 ):
+    """Plot Kolmogorov-Smirnov statistic profiles from a quadratic BiPCA fit.
+
+    Displays the KS statistic as a function of the fitted variance parameters
+    (q, sigma, b, c) for each subsample. For the quantile parameter ``q``,
+    a Chebyshev interpolant is plotted with its global minimum marked.
+
+    Parameters
+    ----------
+    bipcaobj : bipca.bipca.BiPCA or AnnData
+        A fit BiPCA estimator with ``variance_estimator='quadratic'``, or an
+        AnnData object containing quadratic BiPCA results.
+    var : str or list of str, optional
+        Which variance parameters to plot. Accepts 'all', 'q', 'sigma', 'b',
+        or 'c', or a list of these. Default is 'all'.
+    row : bool, optional
+        Unused. Default is True.
+    sharey : bool, optional
+        Whether axes share the y-axis. Default is True.
+    fig : matplotlib.figure.Figure or None, optional
+        Existing figure. If None, a new figure is created.
+    title : str, optional
+        Figure title. Default is ''.
+    axes : list of matplotlib.axes.Axes or None, optional
+        Existing axes to plot into. Must match the number of requested variables.
+    dpi : int, optional
+        Figure resolution. Default is 300.
+    figsize : tuple of float or None, optional
+        Figure size in inches. Default is ``(5 * len(var), 5)``.
+    output : str, optional
+        File path to save the figure. If empty, figure is not saved.
+    labelfontsize : int, optional
+        Font size for axis labels. Default is 16.
+    figkwargs : dict, optional
+        Additional keyword arguments passed to ``get_figure``.
+    """
     # parse the input var
     acceptable_var = ["all", "q", "sigma", "b", "c"]
     if isinstance(var, list):
@@ -580,6 +667,47 @@ def get_density_with_domain(
     scaling="l1",
     **kwargs,
 ):
+    """Compute density estimates over a domain for row-wise input data.
+
+    Optionally applies kernel density estimation (KDE) to each row of
+    the input, evaluates on a grid, and feature-scales the result.
+
+    Parameters
+    ----------
+    data : ndarray of shape (nrows, nfeatures)
+        Row-wise input data to estimate densities for.
+    apply_kde : bool, optional
+        If True (default), fit a KDE to each row and evaluate on a grid.
+        If False, use the raw data values directly.
+    jitter : float, optional
+        Standard deviation of Gaussian jitter added before KDE fitting.
+        Set to 0 to disable. Default is 0.025.
+    npts : int or None, optional
+        Number of evaluation points for the density grid. Default is 1000.
+    X : ndarray or None, optional
+        Custom evaluation grid. If None, a linspace grid is generated.
+    xmin : float, optional
+        Minimum of the evaluation grid when ``X`` is None and ``apply_kde``
+        is False. Default is 0.
+    xmax : float, optional
+        Maximum of the evaluation grid when ``X`` is None and ``apply_kde``
+        is False. Default is 1.
+    prescaled : bool, optional
+        If True, skip scaling of the output densities. Default is False.
+    scaling : {'l1', 'l2'}, optional
+        Scaling method for the density output. Default is 'l1'.
+
+    Returns
+    -------
+    Y : ndarray of shape (nrows, npts)
+        The (optionally scaled) density values.
+    X : ndarray of shape (nrows, npts)
+        The evaluation grid.
+    nrows : int
+        Number of rows in the input data.
+    npts : int
+        Number of evaluation points.
+    """
     # expects row-wise inputs!
     nrows = data.shape[0]
     Y = np.where(np.isnan(data), 0, data)
@@ -654,6 +782,53 @@ def plot_density(
     zorder=0,
     **kwargs,
 ):
+    """Plot filled density curves for each row of the input data.
+
+    Computes density estimates via ``get_density_with_domain`` and renders
+    each row as a filled curve on the given axes.
+
+    Parameters
+    ----------
+    data : ndarray of shape (nrows, nfeatures)
+        Row-wise input data.
+    ax : matplotlib.axes.Axes
+        Axes to plot on.
+    apply_kde : bool, optional
+        Whether to apply KDE. Default is True.
+    origin : float, optional
+        Vertical offset for the density curves. Default is 0.
+    npts : int, optional
+        Number of evaluation points. Default is 1000.
+    X : ndarray or None, optional
+        Custom evaluation grid.
+    xmin : float, optional
+        Minimum of the evaluation grid. Default is 0.
+    xmax : float, optional
+        Maximum of the evaluation grid. Default is 1.
+    prescaled : bool, optional
+        If True, skip density scaling. Default is False.
+    scaling : str, optional
+        Scaling method. Default is 'l1'.
+    color : color-like or array-like, optional
+        Line color(s). Default is 'k'.
+    line_color : color-like or None, optional
+        Explicit line color override.
+    fill_alpha : float, optional
+        Alpha transparency for the filled region. Default is 0.5.
+    fill_color : color-like or None, optional
+        Fill color. If None, derived from line color with ``fill_alpha``.
+    linewidth : float, optional
+        Width of density outline. Default is 0.5.
+    vanish_at : float or False, optional
+        Threshold below which density values are clipped. Default is 1e-3.
+    zorder : int, optional
+        Base z-order for the plotted elements. Default is 0.
+
+    Returns
+    -------
+    ax : matplotlib.axes.Axes
+        The axes with density curves plotted.
+    """
     assert vanish_at is False or isinstance(vanish_at, Number)
 
     Y, X, nrows, npts = get_density_with_domain(
@@ -737,6 +912,54 @@ def ridgeline(
     pad=0.02,
     **kwargs,
 ):
+    """Create a ridgeline (joy) plot of grouped density curves.
+
+    Plots vertically stacked density curves for each group in the data,
+    with configurable overlap and styling.
+
+    Parameters
+    ----------
+    x : ndarray or pandas.DataFrame
+        Input data. If a DataFrame, groups are determined by ``key``.
+    ax : matplotlib.axes.Axes
+        Axes to plot on.
+    f : callable
+        Density plotting function (e.g., ``plot_density`` or ``stacked_violin``).
+        Called as ``f(data, ax, origin=..., zorder=..., **kwargs)``.
+    key : str or None, optional
+        Column name to group by when ``x`` is a DataFrame. Default is 'group'.
+    axis : {0, 1}, optional
+        Axis along which to group the DataFrame. Default is 1.
+    reverse : bool, optional
+        If True, plot groups from bottom to top. Default is False.
+    overlap : float, optional
+        Fraction of overlap between adjacent density curves. Default is 0.05.
+    yticklabels : list of str or None, optional
+        Labels for each group on the y-axis.
+    color : color-like or array-like, optional
+        Line color(s) for the density curves. Default is 'k'.
+    fill_alpha : float, optional
+        Alpha transparency for filled regions. Default is 0.5.
+    fill_color : color-like or None, optional
+        Fill color. If None, derived from ``color`` with ``fill_alpha``.
+    xaxis : bool, optional
+        If True, draw horizontal baseline for each group. Default is True.
+    reindexlevel : int, optional
+        Level for reindexing grouped DataFrame columns. Default is 1.
+    order : list or None, optional
+        Column order for reindexing grouped data.
+    axislinewidth : float, optional
+        Line width of horizontal baselines. Default is 0.7.
+    pad : float, optional
+        Padding around the plot limits. Default is 0.02.
+    **kwargs
+        Additional keyword arguments passed to the density function ``f``.
+
+    Returns
+    -------
+    ax : matplotlib.axes.Axes
+        The axes with the ridgeline plot.
+    """
     if isinstance(x, pd.DataFrame):
         if key is not None:
             groups = x.groupby(key, axis=axis)
@@ -899,6 +1122,55 @@ def stacked_violin(
     zorder=0,
     vanish_at=1e-3,
 ):
+    """Plot symmetric (violin-style) density curves for each row of input data.
+
+    Similar to ``plot_density``, but mirrors the density curve around the
+    origin to create a violin shape.
+
+    Parameters
+    ----------
+    data : ndarray of shape (nrows, nfeatures)
+        Row-wise input data.
+    ax : matplotlib.axes.Axes
+        Axes to plot on.
+    apply_kde : bool, optional
+        Whether to apply KDE. Default is True.
+    origin : float, optional
+        Vertical center for the violin shapes. Default is 0.
+    npts : int, optional
+        Number of evaluation points. Default is 1000.
+    X : ndarray or None, optional
+        Custom evaluation grid.
+    xmin : float, optional
+        Minimum of the evaluation grid. Default is 0.
+    xmax : float, optional
+        Maximum of the evaluation grid. Default is 1.
+    prescaled : bool, optional
+        If True, skip density scaling. Default is False.
+    scaling : str, optional
+        Scaling method. Default is 'l1'.
+    yticklabels : list of str or None, optional
+        Unused. Accepted for compatibility with ``ridgeline``.
+    color : color-like or array-like, optional
+        Line color(s). Default is 'k'.
+    line_color : color-like or None, optional
+        Explicit line color override.
+    fill_alpha : float, optional
+        Alpha transparency for filled region. Default is 0.5.
+    fill_color : color-like or None, optional
+        Fill color. If None, derived from line color.
+    linewidth : float, optional
+        Width of violin outline. Default is 0.5.
+    zorder : int, optional
+        Base z-order for plotted elements. Default is 0.
+    vanish_at : float or False, optional
+        Threshold below which density values are clipped. Default is 1e-3.
+
+    Returns
+    -------
+    ax : matplotlib.axes.Axes
+        The axes with violin curves plotted.
+    """
     assert vanish_at is False or isinstance(vanish_at, Number)
 
     Y, X, nrows, npts = get_density_with_domain(
@@ -969,6 +1241,18 @@ def stacked_violin(
 def set_spine_visibility(
     ax=None, which=["top", "right", "bottom", "left"], status="toggle"
 ):
+    """Set or toggle the visibility of axes spines.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes or None, optional
+        Target axes. If None, uses the current axes.
+    which : str or list of str, optional
+        Spine names to modify. Default is all four: 'top', 'right',
+        'bottom', 'left'.
+    status : bool, 'toggle', or list thereof, optional
+        Visibility to set. 'toggle' flips the current state. Default is 'toggle'.
+    """
     if ax is None:
         ax = plt.gca()
     if not isinstance(which, Iterable) or isinstance(which, str):
@@ -984,6 +1268,27 @@ def set_spine_visibility(
 
 
 def get_figure(fig=None, axes=None, **kwargs):
+    """Get or create a matplotlib figure and axes pair.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure or None, optional
+        Existing figure. If None and ``axes`` is also None, a new figure
+        is created. If None but ``axes`` is provided, the figure is
+        inferred from the first axes object.
+    axes : matplotlib.axes.Axes, list of Axes, or None, optional
+        Existing axes to use.
+    **kwargs
+        Additional keyword arguments passed to ``fig.set()`` (e.g.,
+        ``figsize``, ``dpi``).
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+        The figure object.
+    axes : list of matplotlib.axes.Axes or None
+        The axes, or None if none were provided.
+    """
     if fig is None:
         if axes is None:  # neither fig nor axes was supplied.
             fig = plt.figure()
@@ -1002,6 +1307,25 @@ def get_figure(fig=None, axes=None, **kwargs):
 
 
 def unpack_bipcaobj(bipcaobj):
+    """Extract plotting data from a BiPCA object or AnnData.
+
+    Unpacks the plotting spectrum, variance parameters, eigenvalues,
+    and Marcenko-Pastur statistics from a fitted BiPCA estimator or
+    an AnnData object containing BiPCA results in ``uns['bipca']``.
+
+    Parameters
+    ----------
+    bipcaobj : bipca.bipca.BiPCA or AnnData
+        A fitted BiPCA object or an AnnData with BiPCA results stored
+        in ``uns['bipca']``.
+
+    Returns
+    -------
+    tuple
+        An 18-element tuple containing: plotting_spectrum, isquadratic,
+        rank, M, N, gamma, b, c, bhat, chat, bhat_var, chat_var, kst,
+        theoretical_median, cutoff, presvs, postsvs.
+    """
     if isinstance(bipcaobj, AnnData):
         bipcadict = bipcaobj.uns["bipca"]
         plotting_spectrum = bipcadict["plotting_spectrum"]
@@ -1101,17 +1425,22 @@ def colors_from_clusters(
         A color mapping function. If used in conjunction with `cmap`, this function takes values in the range
         0, 1, ..., len(unique(`labels`))-1 and maps them into a suitable range for the colormap. When `cmap` is None,
         this function should return rgba values given values in the range 0, 1, ... len(unique(`labels`))-1 .
-    marker_function : Callable or dict, optional
-        _description_, by default lambdax:'s'
-    linewidth_function : _type_, optional
-        _description_, by default lambdax:0
-    markersize_function : _type_, optional
-        _description_, by default lambdax:8
+    marker_function : callable or dict, optional
+        Maps cluster index to a matplotlib marker string. Default returns 's'
+        (square) for all clusters.
+    linewidth_function : callable or dict, optional
+        Maps cluster label to a line width for legend handles. Default returns 0.
+    markersize_function : callable or dict, optional
+        Maps cluster label to a marker size for legend handles. Default returns 8.
 
     Returns
     -------
-    _type_
-        _description_
+    color_assignments : ndarray of shape (N, 4)
+        RGBA color array with one color per input label.
+    handles : list of matplotlib.lines.Line2D
+        Legend handles for each unique cluster.
+    label2colormap : dict
+        Mapping from cluster label to RGBA tuple.
     """
     if isinstance(cmap, str):
         cmap = mpl.colormaps[cmap]
@@ -1150,6 +1479,28 @@ def generate_custom_legend_handles(
     linewidth_function=lambda x: 0,
     markersize_function=lambda x: 8,
 ):
+    """Create matplotlib legend handles from a cluster-to-index mapping.
+
+    Parameters
+    ----------
+    cluster_color_assignment : dict
+        Mapping from cluster label to integer index.
+    color_function : callable or dict, optional
+        Maps integer index to a color value. Default is identity.
+    marker_function : callable or dict, optional
+        Maps cluster label to a marker string. Default returns 's'.
+    linewidth_function : callable or dict, optional
+        Maps cluster label to a line width. Default returns 0.
+    markersize_function : callable or dict, optional
+        Maps cluster label to a marker size. Default returns 8.
+
+    Returns
+    -------
+    handles : list of matplotlib.lines.Line2D
+        Legend handles for each cluster.
+    label2colormap : dict
+        Mapping from cluster label to RGBA tuple.
+    """
     if isinstance(color_function, dict):
         color_function = color_function.get
     if isinstance(marker_function, dict):
@@ -1178,6 +1529,28 @@ def generate_custom_legend_handles(
 
 
 def add_colored_tick(ax, val, label, dim="x", color="red", **tick_params):
+    """Add colored tick marks to an axes via an overlay inset axes.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The axes to add colored ticks to.
+    val : float or array-like
+        Tick position(s).
+    label : str or list of str
+        Tick label(s).
+    dim : {'x', 'y'}, optional
+        Which axis to add ticks to. Default is 'x'.
+    color : color-like, optional
+        Color for the tick marks and labels. Default is 'red'.
+    **tick_params
+        Additional keyword arguments passed to ``Axes.tick_params``.
+
+    Returns
+    -------
+    bgaxis : matplotlib.axes.Axes
+        The overlay inset axes containing the colored ticks.
+    """
     if not isinstance(val, Iterable):
         val = [val]
         label = [label]
@@ -1297,6 +1670,8 @@ def add_rows_to_figure(
 
 
 class MajorSymLogLocator(SymmetricalLogLocator):
+    """Tick locator for symlog-scaled axes that places ticks at major orders of magnitude."""
+
     def __init__(self):
         super().__init__(base=10.0, linthresh=1.0)
 
@@ -1366,22 +1741,26 @@ class MajorSymLogLocator(SymmetricalLogLocator):
 
 
 def symlogfmt(x, pos):
+    """Format tick values for symlog scale, stripping trailing zeros."""
     return f"{x:.6f}".rstrip("0")
 
 
 def extract_color_list_from_string(string):
+    """Parse a space-delimited, quoted color string into a list of color strings."""
     string = string.replace('"', "")
     string = string.split(" ")
     return string
 
 
 def get_alpha_cmap_from_cmap(cmap, alpha=1):
+    """Create a new colormap from an existing one with a uniform alpha channel."""
     cmap_arr = cmap(np.arange(cmap.N))
     cmap_arr[:, -1] = alpha
     return mpl.colors.ListedColormap(cmap_arr)
 
 
 def aaas_cmap(alpha=1):
+    """Return a ListedColormap using the AAAS (Science) journal color palette."""
     string = '"#3B4992FF" "#EE0000FF" "#008B45FF" "#631879FF" "#008280FF" "#BB0021FF" "#5F559BFF" "#A20056FF" "#808180FF" "#1B1919FF"'
     output = extract_color_list_from_string(string)
     cmap = mpl.colors.ListedColormap(output)
@@ -1389,6 +1768,7 @@ def aaas_cmap(alpha=1):
 
 
 def gg_cmap(alpha=1):
+    """Return a ListedColormap using the default ggplot2 color palette."""
     string = '"#F8766D" "#D89000" "#A3A500" "#39B600" "#00BF7D" "#00BFC4" "#00B0F6" "#9590FF" "#E76BF3" "#FF62BC"'
     output = extract_color_list_from_string(string)
     cmap = mpl.colors.ListedColormap(output)

--- a/python/bipca/utils.py
+++ b/python/bipca/utils.py
@@ -1,4 +1,5 @@
-"""Summary
+"""Utility functions for BiPCA: type checking, matrix manipulation, sparse operations,
+dictionary helpers, and caching.
 """
 from functools import singledispatch
 import numpy as np
@@ -110,35 +111,35 @@ def fill_missing(X):
 
 
 def _is_vector(x):
-    """Summary
+    """Check whether an array-like is a vector (1-D or has a singleton dimension).
 
     Parameters
     ----------
-    x : TYPE
-        Description
+    x : array-like
+        Array with ``ndim`` and ``shape`` attributes.
 
     Returns
     -------
-    TYPE
-        Description
+    bool
+        True if ``x`` is 1-D or has at least one dimension of size 1.
     """
     return x.ndim == 1 or x.shape[0] == 1 or x.shape[1] == 1
 
 
 def _xor(lst, obj):
-    """Summary
+    """Check that exactly one element of ``lst`` equals ``obj``.
 
     Parameters
     ----------
-    lst : TYPE
-        Description
-    obj : TYPE
-        Description
+    lst : list
+        List of elements to compare against ``obj``.
+    obj : object
+        The target value to match.
 
     Returns
     -------
-    TYPE
-        Description
+    bool
+        True if exactly one element in ``lst`` equals ``obj``.
     """
     condeval = [ele == obj for ele in lst]
     condeval = sum(condeval)
@@ -146,24 +147,27 @@ def _xor(lst, obj):
 
 
 def zero_pad_vec(nparray, final_length):
-    """Summary
+    """Zero-pad a vector to a specified length.
+
+    Appends zeros along the largest axis of the input. The input must be
+    1-D or have at least one dimension of size 1.
 
     Parameters
     ----------
-    nparray : TYPE
-        Description
-    final_length : TYPE
-        Description
+    nparray : numpy.ndarray
+        Input vector to pad.
+    final_length : int
+        Desired length of the output vector along its largest axis.
 
     Returns
     -------
-    TYPE
-        Description
+    numpy.ndarray
+        Zero-padded vector of length ``final_length``.
 
     Raises
     ------
     ValueError
-        Description
+        If ``nparray`` has more than one dimension and neither dimension is 1.
     """
     # pad a vector (nparray) to have length final_length by adding zeros
     # adds to the largest axis of the vector if it has 2 dimensions
@@ -449,21 +453,25 @@ def rename_keys_in_dict(data_dict, key_pairs):
 
 
 def ischanged_dict(old_dict, new_dict, keys_ignore=[]):
-    """Summary
+    """Check whether two dictionaries differ in keys or values.
+
+    Compares ``new_dict`` against ``old_dict``, detecting added, removed,
+    or changed entries. Keys listed in ``keys_ignore`` are excluded from
+    the removal check.
 
     Parameters
     ----------
-    old_dict : TYPE
-        Description
-    new_dict : TYPE
-        Description
+    old_dict : dict
+        The original dictionary.
+    new_dict : dict
+        The updated dictionary to compare against ``old_dict``.
     keys_ignore : list, optional
-        Description
+        Keys in ``old_dict`` to ignore when checking for removals.
 
     Returns
     -------
-    TYPE
-        Description
+    bool
+        True if the dictionaries differ, False otherwise.
     """
     ischanged = False
 
@@ -484,21 +492,23 @@ def ischanged_dict(old_dict, new_dict, keys_ignore=[]):
 
 
 def issparse(X, check_torch=True, check_scipy=True):
-    """Summary
+    """Check whether ``X`` is a sparse matrix or tensor.
+
+    Supports both PyTorch sparse tensors and SciPy sparse matrices.
 
     Parameters
     ----------
-    X : TYPE
-        Description
+    X : array-like
+        Input array, tensor, or matrix.
     check_torch : bool, optional
-        Description
+        If True, check for PyTorch sparse tensor layout. Default is True.
     check_scipy : bool, optional
-        Description
+        If True, check for SciPy sparse matrix types. Default is True.
 
     Returns
     -------
-    TYPE
-        Description
+    bool
+        True if ``X`` is sparse according to the enabled checks, False otherwise.
     """
     # Checks if X is a sparse tensor or matrix
     # returns False if not sparse
@@ -517,17 +527,17 @@ def is_tensor(X):
 
 
 def is_scipy(X):
-    """Summary
+    """Check whether ``X`` is a NumPy ndarray or SciPy sparse matrix.
 
     Parameters
     ----------
-    X : TYPE
-        Description
+    X : object
+        Input to check.
 
     Returns
     -------
-    TYPE
-        Description
+    bool
+        True if ``X`` is a ``numpy.ndarray`` or ``scipy.sparse.spmatrix``.
     """
     valid_X = [isinstance(X, np.ndarray), sparse.issparse(X)]
     if not any(valid_X):
@@ -537,42 +547,47 @@ def is_scipy(X):
 
 
 def attr_exists_not_none(obj, attr):
-    """Summary
+    """Check whether ``obj`` has the attribute ``attr`` and it is not None.
 
     Parameters
     ----------
-    obj : TYPE
-        Description
-    attr : TYPE
-        Description
+    obj : object
+        The object to inspect.
+    attr : str
+        The attribute name to look for.
 
     Returns
     -------
-    TYPE
-        Description
+    bool
+        True if the attribute exists and is not None.
     """
     return hasattr(obj, attr) and not getattr(obj, attr) is None
 
 
 def make_tensor(X, keep_sparse=True):
-    """Summary
+    """Convert a matrix to a PyTorch tensor.
+
+    Handles NumPy arrays, SciPy sparse matrices, and existing PyTorch tensors.
+    Sparse inputs are converted to sparse COO or CSR tensors when
+    ``keep_sparse`` is True.
 
     Parameters
     ----------
-    X : TYPE
-        Description
+    X : numpy.ndarray, scipy.sparse.spmatrix, or torch.Tensor
+        Input matrix to convert.
     keep_sparse : bool, optional
-        Description
+        If True, preserve sparsity when converting SciPy sparse matrices.
+        If False, convert sparse inputs to dense tensors. Default is True.
 
     Returns
     -------
-    TYPE
-        Description
+    torch.Tensor
+        A double-precision PyTorch tensor.
 
     Raises
     ------
     TypeError
-        Description
+        If ``X`` is not a sparse matrix, NumPy array, or PyTorch tensor.
     """
     if sparse.issparse(X):
         if keep_sparse:
@@ -628,24 +643,29 @@ def _(obj,reference):
         raise TypeError("Unsupported typecasting operation.")
 
 def make_scipy(X, keep_sparse=True):
-    """Summary
+    """Convert a matrix to a NumPy array or SciPy sparse matrix.
+
+    If ``X`` is already a NumPy array or SciPy sparse matrix, it is returned
+    unchanged. PyTorch sparse tensors are converted to their SciPy equivalents
+    (COO or CSR), and dense tensors are converted via ``.numpy()``.
 
     Parameters
     ----------
-    X : TYPE
-        Description
+    X : numpy.ndarray, scipy.sparse.spmatrix, or torch.Tensor
+        Input matrix to convert.
     keep_sparse : bool, optional
-        Description
+        Currently unused; sparse tensors are always converted to sparse
+        SciPy matrices. Default is True.
 
     Returns
     -------
-    TYPE
-        Description
+    numpy.ndarray or scipy.sparse.spmatrix
+        The converted matrix.
 
     Raises
     ------
-    TypeError
-        Description
+    ValueError
+        If ``X`` is a sparse tensor with an unsupported layout.
     """
     if is_scipy(X):
         return X
@@ -852,11 +872,10 @@ def nz_along(M, axis=0):
     Raises
     ------
     TypeError
-        Description
+        If ``M`` is not a NumPy array, SciPy sparse matrix, or PyTorch tensor,
+        or if ``axis`` is not an integer.
     ValueError
-        Description
-    TypeError
-    ValueError
+        If ``axis`` is out of range for the dimensions of ``M``.
     """
 
     if not is_scipy(M) and not is_tensor(M):


### PR DESCRIPTION
Replace all placeholder docstrings ("Summary", "TYPE", "Description") with accurate NumPy-style documentation across 8 core module files. Covers classes (BiPCA, Sinkhorn, SVD, Shrinker, MarcenkoPastur, MeanCenteredMatrix, ScanpyPipeline), utility functions, plotting, CLI, and data generation functions. Adds module-level docstring to __init__.py.